### PR TITLE
Viewer roles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,6 @@
 {
+	"editor.detectIndentation": false,
+	"editor.tabSize": 2,
+	"editor.formatOnSave": true,
+	"editor.insertSpaces": false,
 }

--- a/meteor-app/imports/api/contexts/userContext.tsx
+++ b/meteor-app/imports/api/contexts/userContext.tsx
@@ -5,12 +5,14 @@ import { withTracker } from 'meteor/react-meteor-data'
 export const UserContext = createContext({user: {}, userId: '', role: '', viewerId: '', isLoggedIn: false})
 
 export const withAccount = withTracker((props) => {
+  let viewerId = ''
   const user = Meteor.isServer ? null : Meteor.user()
+  if (user) viewerId = user.profile.viewer_id
   const userId = Meteor.isServer ? null : Meteor.userId()
 	const roleAssignment = Meteor.roleAssignment.findOne({ 'user._id': userId })
   let role = roleAssignment?.role?._id
-  let viewer = Meteor.users.findOne({ 'user._id': userId })
-  let viewerId = viewer?.profile?.viewer_id
+  
+  
 	
   return {
     user,

--- a/meteor-app/imports/api/contexts/userContext.tsx
+++ b/meteor-app/imports/api/contexts/userContext.tsx
@@ -2,18 +2,21 @@ import { Meteor } from 'meteor/meteor'
 import React, { createContext } from 'react'
 import { withTracker } from 'meteor/react-meteor-data'
 
-export const UserContext = createContext({user: {}, userId: '', role: '', isLoggedIn: false})
+export const UserContext = createContext({user: {}, userId: '', role: '', viewerId: '', isLoggedIn: false})
 
 export const withAccount = withTracker((props) => {
   const user = Meteor.isServer ? null : Meteor.user()
   const userId = Meteor.isServer ? null : Meteor.userId()
 	const roleAssignment = Meteor.roleAssignment.findOne({ 'user._id': userId })
-	let role = roleAssignment?.role?._id
+  let role = roleAssignment?.role?._id
+  let viewer = Meteor.users.findOne({ 'user._id': userId })
+  let viewerId = viewer?.profile?.viewer_id
 	
   return {
     user,
     userId,
-		role,
+    role,
+    viewerId,
     isLoggedIn: !!userId
   }
 })

--- a/meteor-app/imports/api/types/accounts.tsx
+++ b/meteor-app/imports/api/types/accounts.tsx
@@ -7,11 +7,12 @@ export interface Account {
 export interface Viewer {
 	_id: string;
 	username: string;
-  emails: Array<ViewerEmail>;
+	emails: Array<ViewerEmail>;
+	tags: Array<string>;
 	profile: {
 		first_name: string;
-    last_name: string;
-    viewer_id: string;
+		last_name: string;
+		viewer_id: string;
 		[key: string]: string | number | Object | null | undefined;
 	}
 }

--- a/meteor-app/imports/api/types/accounts.tsx
+++ b/meteor-app/imports/api/types/accounts.tsx
@@ -7,10 +7,11 @@ export interface Account {
 export interface Viewer {
 	_id: string;
 	username: string;
-	emails: Array<ViewerEmail>;
+  emails: Array<ViewerEmail>;
 	profile: {
 		first_name: string;
-		last_name: string;
+    last_name: string;
+    viewer_id: string;
 		[key: string]: string | number | Object | null | undefined;
 	}
 }

--- a/meteor-app/imports/api/types/reports.tsx
+++ b/meteor-app/imports/api/types/reports.tsx
@@ -10,13 +10,14 @@ export interface Table {
 	type: string; // collection - a table that uses a collection for generating rows. static - user defined dimensions, non looping
 	columns: Array<TableColumn>; // the columns within a table
 	rows: Array<TableRow>; // the rows within a table, if type: collection, rows are generated, if type:static, rows are pre defined by user
-	collection: string; // the collection used if table is collection driven
+  collection: string; // the collection used if table is collection driven
+  filter: number; // index of the column that the filter is on. 
 }
 export interface TableColumn {
 	id: string; // the uuid of the column within a table
 	label: string; // used for display
 	formulaId?: string; // if the column has a formula applied to it
-	property: string; // the property of a mongo object, from collection driven tables
+  property: string; // the property of a mongo object, from collection driven tables
 	enum: string; // defines the intended enumeration for the cell under a column
 }
 export interface TableRow {

--- a/meteor-app/imports/api/types/reports.tsx
+++ b/meteor-app/imports/api/types/reports.tsx
@@ -2,7 +2,8 @@ export interface ReportStructure {
 	_id: string | null | undefined; // the mongoId of the report object
 	name: string;
 	tables: Array<Table>; // all the tables within a report
-	formulas: Array<Formula>; // the formulas to process when viewing a report
+  formulas: Array<Formula>; // the formulas to process when viewing a report
+  public: boolean;
 }
 export interface Table {
 	id: string; // unique id of the table within a report
@@ -11,7 +12,6 @@ export interface Table {
 	columns: Array<TableColumn>; // the columns within a table
 	rows: Array<TableRow>; // the rows within a table, if type: collection, rows are generated, if type:static, rows are pre defined by user
   collection: string; // the collection used if table is collection driven
-  filter: number; // index of the column that the filter is on. 
 }
 export interface TableColumn {
 	id: string; // the uuid of the column within a table
@@ -60,7 +60,8 @@ export interface FormulaQuery {
 
 export interface ReportData {
   _id: string | undefined;
-	collectionName: string;
+  collectionName: string;
+  viewerId?: string;
 	[key: string]: string | number | Object | null | undefined;
 
 }

--- a/meteor-app/imports/api/types/reports.tsx
+++ b/meteor-app/imports/api/types/reports.tsx
@@ -2,8 +2,9 @@ export interface ReportStructure {
 	_id: string | null | undefined; // the mongoId of the report object
 	name: string;
 	tables: Array<Table>; // all the tables within a report
-  formulas: Array<Formula>; // the formulas to process when viewing a report
-  public: boolean;
+	formulas: Array<Formula>; // the formulas to process when viewing a report
+	public: boolean;	// makes all tables in report public
+	permissions: Array<string>; // These are the permissable tags for viewers
 }
 export interface Table {
 	id: string; // unique id of the table within a report
@@ -11,13 +12,13 @@ export interface Table {
 	type: string; // collection - a table that uses a collection for generating rows. static - user defined dimensions, non looping
 	columns: Array<TableColumn>; // the columns within a table
 	rows: Array<TableRow>; // the rows within a table, if type: collection, rows are generated, if type:static, rows are pre defined by user
-  collection: string; // the collection used if table is collection driven
+	collection: string; // the collection used if table is collection driven
 }
 export interface TableColumn {
 	id: string; // the uuid of the column within a table
 	label: string; // used for display
 	formulaId?: string; // if the column has a formula applied to it
-  property: string; // the property of a mongo object, from collection driven tables
+	property: string; // the property of a mongo object, from collection driven tables
 	enum: string; // defines the intended enumeration for the cell under a column
 }
 export interface TableRow {
@@ -59,9 +60,9 @@ export interface FormulaQuery {
 }
 
 export interface ReportData {
-  _id: string | undefined;
-  collectionName: string;
-  viewerId?: string;
+	_id: string | undefined;
+	collectionName: string;
+	viewer_id?: string;
 	[key: string]: string | number | Object | null | undefined;
 
 }

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -7,7 +7,7 @@ import { Button } from '../components/buttons'
 import { Input } from '../components/inputs'
 import useSubscription from '../../api/hooks'
 import { ReportStructure, TableColumn } from '../../api/types/reports';
-import {useParams} from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Report_Structures } from '../../api/collections'
 
 export const Report_Builder = () => {
@@ -16,25 +16,24 @@ export const Report_Builder = () => {
 	const loading1 = useSubscription('ReportData')
 	const loading2 = useSubscription('ReportStructure')
 
-	const [reportStructure, setReportStructure] = useState<ReportStructure>({_id: id, name: '', tables: [], formulas: [], public: false})
-	const [cellSelected, setCellSelected] = useState({tableId: '', cellId: ''})
+	const [reportStructure, setReportStructure] = useState<ReportStructure>({ _id: id, name: '', tables: [], formulas: [], public: false })
+	const [cellSelected, setCellSelected] = useState({ tableId: '', cellId: '' })
 	const [userCollections, setUserCollections] = useState([])
 	const [showToolBar, setShowToolBar] = useState(false)
 	const [selectedTable, setSelectedTable] = useState(null)
 	const [selectedColumn, setSelectedColumn] = useState(null)
-  const [selectedColumnFormula, setSelectedColumnFormula] = useState(null)
-  const [access, setAccess] = useState('Make Public')
+	const [selectedColumnFormula, setSelectedColumnFormula] = useState(null)
 
 	useEffect(() => {
-		if(!loading1 && !loading2) {
+		if (!loading1 && !loading2) {
 
 			Meteor.call('Fetch_Collection_Names', (error, result) => {
-				if(error) console.log(error)
-				if(result) setUserCollections(result)
+				if (error) console.log(error)
+				if (result) setUserCollections(result)
 			})
 
-			if(id) {
-				const reportQuery = Report_Structures.findOne({_id: id})
+			if (id) {
+				const reportQuery = Report_Structures.findOne({ _id: id })
 				setReportStructure(reportQuery)
 			}
 		}
@@ -49,12 +48,12 @@ export const Report_Builder = () => {
 			id: uuidv4(),
 			title: '',
 			type: type,
-			columns: [{id: uuidv4(), label: '', property: '', enum: ''}],
-			rows: [], 
-      collection: ''
+			columns: [{ id: uuidv4(), label: '', property: '', enum: '' }],
+			rows: [],
+			collection: ''
 		}
 		setReportStructure(prevState => {
-			return { ...prevState,  tables: [...reportStructure.tables, table] }
+			return { ...prevState, tables: [...reportStructure.tables, table] }
 		});
 		setSelectedTable(table)
 		setShowToolBar(true)
@@ -62,7 +61,7 @@ export const Report_Builder = () => {
 
 	const handleReportName = (value) => {
 		setReportStructure(prevState => {
-			return { ...prevState,  name: value }
+			return { ...prevState, name: value }
 		});
 	}
 
@@ -70,15 +69,15 @@ export const Report_Builder = () => {
 		let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
 		reportStructure.tables[tableIndex].collection = collectionName
 		setReportStructure(prevState => {
-			return { ...prevState,  tables: reportStructure.tables }
+			return { ...prevState, tables: reportStructure.tables }
 		});
-  }
+	}
 
 	const addColumnToTable = (tableId: string) => {
 		const updatedTables = reportStructure.tables.map(table => {
-			if(table.id === tableId) {
-				table.columns.push({id: uuidv4(), label: '', property: '', enum: ''})
-				table.rows.forEach(row => { 
+			if (table.id === tableId) {
+				table.columns.push({ id: uuidv4(), label: '', property: '', enum: '' })
+				table.rows.forEach(row => {
 					row.cells.push({
 						id: uuidv4(),
 						index: table.columns.length,
@@ -87,57 +86,55 @@ export const Report_Builder = () => {
 						propertyValue: '',
 						value: '',
 						expression: '',
-					}) 
+					})
 				})
 			}
 			return table
 		})
 		setReportStructure(prevState => {
-			return { ...prevState,  tables: updatedTables }
+			return { ...prevState, tables: updatedTables }
 		});
-  }
-  
-  const handleAccess = () => {
-    if (access === 'Make Public') {
-      setAccess('Make Private')
-      setReportStructure(prevState => {
-				return { ...prevState,  public: true }
+	}
+
+	const handleAccess = () => {
+		if (!reportStructure.public) {
+			setReportStructure(prevState => {
+				return { ...prevState, public: true }
 			});
-    } else {
-      setAccess('Make Public')
-      setReportStructure(prevState => {
-				return { ...prevState,  public: false }
+		} else {
+			setReportStructure(prevState => {
+				return { ...prevState, public: false }
 			});
-    }
-  }
+		}
+	}
 
 	// deleting a column also means deleting coresponding formulas
 	const deleteColumn = (tableId, columnIndex) => {
 		let c = confirm("Are you sure you want to delete this column?")
-		if(c) {
+		if (c) {
 			let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
 			reportStructure.tables[tableIndex].columns.splice(columnIndex, 1);
 			let formulaIndex = reportStructure.formulas.findIndex(formula => (formula.tableId === tableId && formula.columnIndex === columnIndex))
 			reportStructure.formulas.splice(formulaIndex, 1);
 			setReportStructure(prevState => {
-				return { ...prevState,  tables: reportStructure.tables, formulas: reportStructure.formulas }
+				return { ...prevState, tables: reportStructure.tables, formulas: reportStructure.formulas }
 			});
 		}
 	}
 
 	const addRowToTable = (tableId: string) => {
 		const cells = (tableColumns: Array<TableColumn>) => {
-			return tableColumns.map(() => ({id: uuidv4()}))
+			return tableColumns.map(() => ({ id: uuidv4() }))
 		}
 		const updatedTables = reportStructure.tables.map(table => {
-			if(table.id === tableId) {
-				table.rows.push({id: uuidv4(), cells: cells(table.columns)})
+			if (table.id === tableId) {
+				table.rows.push({ id: uuidv4(), cells: cells(table.columns) })
 			}
 			return table
 		})
 
 		setReportStructure(prevState => {
-			return { ...prevState,  tables: updatedTables }
+			return { ...prevState, tables: updatedTables }
 		});
 	}
 
@@ -146,7 +143,7 @@ export const Report_Builder = () => {
 
 		reportStructure.tables[tableIndex].columns[columnIndex].label = label
 		setReportStructure(prevState => {
-			return { ...prevState,  tables: reportStructure.tables }
+			return { ...prevState, tables: reportStructure.tables }
 		});
 	}
 
@@ -155,17 +152,17 @@ export const Report_Builder = () => {
 
 		reportStructure.tables[tableIndex].columns[columnIndex].property = property
 		setReportStructure(prevState => {
-			return { ...prevState,  tables: reportStructure.tables }
+			return { ...prevState, tables: reportStructure.tables }
 		});
 	}
 
 	const deleteTable = (tableId) => {
 		let c = confirm("Are you sure you want to delete this table?")
-		if(c) {
+		if (c) {
 			let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
 			reportStructure.tables.splice(tableIndex, 1);
 			setReportStructure(prevState => {
-				return { ...prevState,  tables: reportStructure.tables }
+				return { ...prevState, tables: reportStructure.tables }
 			});
 			setShowToolBar(false)
 			setSelectedTable(null)
@@ -176,14 +173,14 @@ export const Report_Builder = () => {
 		let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
 		reportStructure.tables[tableIndex].title = title
 		setReportStructure(prevState => {
-			return { ...prevState,  tables : reportStructure.tables }
+			return { ...prevState, tables: reportStructure.tables }
 		});
 	}
 
 	const handleFormulaUpdate = (formula) => {
 		let tableIndex = reportStructure.tables.findIndex(table => table.id === formula.tableId)
 		let existingFormula = reportStructure.formulas.find(each => (each.tableId === formula.tableId && each.columnId === formula.columnId))
-		if(!existingFormula) { // add a new formula to the set
+		if (!existingFormula) { // add a new formula to the set
 			formula.id = uuidv4()
 			// apply formulaId to column
 			reportStructure.tables[tableIndex].columns[formula.columnIndex].formulaId = formula.id
@@ -194,7 +191,7 @@ export const Report_Builder = () => {
 			let formulaIndex = reportStructure.formulas.findIndex(each => each.id === existingFormula.id)
 			reportStructure.formulas[formulaIndex] = formula
 			setReportStructure(prevState => {
-				return { ...prevState,  formulas: reportStructure.formulas }
+				return { ...prevState, formulas: reportStructure.formulas }
 			});
 		}
 	}
@@ -202,7 +199,7 @@ export const Report_Builder = () => {
 	const handleFormulaRemoval = (tableId, columnIndex, columnId) => {
 		let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
 		let existingFormula = reportStructure.formulas.find(each => (each.tableId === tableId && each.columnId === columnId))
-		if(existingFormula) {
+		if (existingFormula) {
 			reportStructure.tables[tableIndex].columns[columnIndex].formulaId = undefined
 			let formulaIndex = reportStructure.formulas.findIndex(each => each.id === existingFormula.id)
 			reportStructure.formulas.splice(formulaIndex, 1);
@@ -213,7 +210,7 @@ export const Report_Builder = () => {
 	}
 
 	const toggleToolBarForTable = (table) => {
-		if(table) {
+		if (table) {
 			setSelectedColumn(null)
 			setSelectedColumnFormula(null)
 			setSelectedTable(table)
@@ -222,11 +219,11 @@ export const Report_Builder = () => {
 	}
 
 	const toggleToolBarForColumn = (tableId, column, columnIndex) => {
-		if(column) {
+		if (column) {
 			setSelectedTable(null)
-			setSelectedColumn({tableId, column, columnIndex})
+			setSelectedColumn({ tableId, column, columnIndex })
 			const columnSpecificFormula = reportStructure.formulas.find(formula => (formula.tableId === tableId && formula.columnId === column.id))
-			if(columnSpecificFormula) {
+			if (columnSpecificFormula) {
 				setSelectedColumnFormula(columnSpecificFormula);
 			} else { setSelectedColumnFormula(null) }
 			setShowToolBar(true)
@@ -235,21 +232,21 @@ export const Report_Builder = () => {
 
 	const saveReport = () => {
 		Meteor.call('Upsert_Report', reportStructure, (error, result) => {
-			if(error) console.log(error)
-			if(result) {
+			if (error) console.log(error)
+			if (result) {
 				setReportStructure(result)
 				toast.success('Report Saved!')
 			}
 		})
 	}
 
-  return (
-    <div className='h-screen p-6 bg-gray-100'>
+	return (
+		<div className='h-screen p-6 bg-gray-100'>
 
 			{/* ToolBar */}
-			{showToolBar && 
-				<ToolBar 
-					table={selectedTable} 
+			{showToolBar &&
+				<ToolBar
+					table={selectedTable}
 					handleTableTitleUpdate={handleTableTitleUpdate}
 					userCollections={userCollections}
 					setCollectionForTable={setCollectionForTable}
@@ -265,20 +262,20 @@ export const Report_Builder = () => {
 					handleFormulaRemoval={handleFormulaRemoval}
 				/>
 			}
-			
+
 			<div className="flex justify-between mx-2 mb-5 w-9/12">
 				<Input placeholder={'Enter Report Name'} label={'Report Name'} value={reportStructure.name} flex={'flex'}
 					onChange={(e) => handleReportName(e.target.value)}
 				/>
 
 				<div className="ml-6 mr-4">
-          <Button onClick={() => handleAccess()} text={access} color="blue"/>
-					<Button onClick={() => createNewTable('static')} text="+ New Static Table" color="green"/>
-					<Button onClick={() => createNewTable('collection')} text="+ New Collection Table" color="green"/>
-					<Button onClick={() => saveReport()} text="Save Report" color="blue"/>
+					<Button onClick={() => handleAccess()} text={reportStructure.public ? "Make Tables Private" : "Make Tables Public"} color="blue" />
+					<Button onClick={() => createNewTable('static')} text="+ New Static Table" color="green" />
+					<Button onClick={() => createNewTable('collection')} text="+ New Collection Table" color="green" />
+					<Button onClick={() => saveReport()} text="Save Report" color="blue" />
 				</div>
 			</div>
-			
+
 
 			<div className="flex-col w-9/12 pr-1 overflow-auto">
 
@@ -288,30 +285,30 @@ export const Report_Builder = () => {
 
 						<div className="flex justify-between">
 							<p className="text-md font-medium mb-3">{table.title}</p>
-							<Button onClick={() => toggleToolBarForTable(table)} text="Edit ✏️" color="indigo"/>
+							<Button onClick={() => toggleToolBarForTable(table)} text="Edit ✏️" color="indigo" />
 						</div>
-						
+
 
 						<div>
 
 							{/* column headers */}
-							<div className="flex"> 
+							<div className="flex">
 								{table.columns.map((col, i) => {
-									return <div 
-										key={col.id} 
-										className="flex justify-center items-center h-8 w-40 max-w-sm m-1 border-2 border-indigo-200 hover:border-indigo-100 rounded-md bg-white cursor-pointer" 
+									return <div
+										key={col.id}
+										className="flex justify-center items-center h-8 w-40 max-w-sm m-1 border-2 border-indigo-200 hover:border-indigo-100 rounded-md bg-white cursor-pointer"
 										onClick={() => toggleToolBarForColumn(table.id, col, i)}>
 										<span>{col.label}</span>
 									</div>
 								})}
 							</div>
-							
+
 							{/* rows and cells - if static driven */}
 							{table.rows.map((row) => {
 								return <div key={row.id} className="flex">
 									{row.cells.map((cell) => {
-										return <div key={cell.id} className="flex justify-center items-center h-8 w-40 max-w-sm m-1 border-2 border-indigo-200 hover:border-indigo-100 rounded-md bg-white cursor-pointer" 
-											onClick={() => setCellSelected({tableId: table.id, cellId: cell.id})}>
+										return <div key={cell.id} className="flex justify-center items-center h-8 w-40 max-w-sm m-1 border-2 border-indigo-200 hover:border-indigo-100 rounded-md bg-white cursor-pointer"
+											onClick={() => setCellSelected({ tableId: table.id, cellId: cell.id })}>
 											<div></div>
 										</div>
 									})}
@@ -330,11 +327,11 @@ export const Report_Builder = () => {
 							})}
 
 						</div>
-						
+
 					</div>
 				))}
 			</div>
-			
-    </div>
-  );
+
+		</div>
+	);
 };

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -51,7 +51,7 @@ export const Report_Builder = () => {
 			columns: [{id: uuidv4(), label: '', property: '', enum: ''}],
 			rows: [], 
       collection: '',
-      filter: 0 // I hardcoded this in for testing
+      filter: null // I hardcoded this in for testing
 		}
 		setReportStructure(prevState => {
 			return { ...prevState,  tables: [...reportStructure.tables, table] }

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -50,7 +50,8 @@ export const Report_Builder = () => {
 			type: type,
 			columns: [{id: uuidv4(), label: '', property: '', enum: ''}],
 			rows: [], 
-			collection: ''
+      collection: '',
+      filter: 0 // I hardcoded this in for testing
 		}
 		setReportStructure(prevState => {
 			return { ...prevState,  tables: [...reportStructure.tables, table] }

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -16,13 +16,14 @@ export const Report_Builder = () => {
 	const loading1 = useSubscription('ReportData')
 	const loading2 = useSubscription('ReportStructure')
 
-	const [reportStructure, setReportStructure] = useState<ReportStructure>({_id: id, name: '', tables: [], formulas: []})
+	const [reportStructure, setReportStructure] = useState<ReportStructure>({_id: id, name: '', tables: [], formulas: [], public: false})
 	const [cellSelected, setCellSelected] = useState({tableId: '', cellId: ''})
 	const [userCollections, setUserCollections] = useState([])
 	const [showToolBar, setShowToolBar] = useState(false)
 	const [selectedTable, setSelectedTable] = useState(null)
 	const [selectedColumn, setSelectedColumn] = useState(null)
-	const [selectedColumnFormula, setSelectedColumnFormula] = useState(null)
+  const [selectedColumnFormula, setSelectedColumnFormula] = useState(null)
+  const [access, setAccess] = useState('Make Public')
 
 	useEffect(() => {
 		if(!loading1 && !loading2) {
@@ -50,8 +51,7 @@ export const Report_Builder = () => {
 			type: type,
 			columns: [{id: uuidv4(), label: '', property: '', enum: ''}],
 			rows: [], 
-      collection: '',
-      filter: null // I hardcoded this in for testing
+      collection: ''
 		}
 		setReportStructure(prevState => {
 			return { ...prevState,  tables: [...reportStructure.tables, table] }
@@ -95,7 +95,21 @@ export const Report_Builder = () => {
 		setReportStructure(prevState => {
 			return { ...prevState,  tables: updatedTables }
 		});
-	}
+  }
+  
+  const handleAccess = () => {
+    if (access === 'Make Public') {
+      setAccess('Make Private')
+      setReportStructure(prevState => {
+				return { ...prevState,  public: true }
+			});
+    } else {
+      setAccess('Make Public')
+      setReportStructure(prevState => {
+				return { ...prevState,  public: false }
+			});
+    }
+  }
 
 	// deleting a column also means deleting coresponding formulas
 	const deleteColumn = (tableId, columnIndex) => {
@@ -257,6 +271,7 @@ export const Report_Builder = () => {
 					onChange={(e) => handleReportName(e.target.value)}
 				/>
 				<div className="ml-6">
+          <Button onClick={() => handleAccess()} text={access} color="blue"/>
 					<Button onClick={() => createNewTable('static')} text="+ New Static Table" color="green"/>
 					<Button onClick={() => createNewTable('collection')} text="+ New Collection Table" color="green"/>
 					<Button onClick={() => saveReport()} text="Save Report" color="blue"/>

--- a/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
@@ -8,6 +8,15 @@ export const TableToolBar = ({
 	addColumnToTable, addRowToTable, deleteTable
 }) => {
 
+  const [showFilter, setShowFilter] = useState(false)
+  const [removeFilter, setRemoveFilter] = useState(!(table.filter === null))
+
+  const propertySelector = (index : number) => {
+    setShowFilter(false)
+    table.filter = index
+    setRemoveFilter(true)
+  }
+
 	return (
 		<>
 			{/* Table type */}
@@ -54,8 +63,25 @@ export const TableToolBar = ({
 					{table.type === 'static' && 
 						<Button onClick={() => addRowToTable(table.id)} text="+ Row" color="green"/>
 					}
+
+          
 				</div>
 			</div>
+      <Button onClick={() => setShowFilter(true)} text="Viewer Filter" color="blue"/>
+      <hr/>
+      {showFilter && table.columns.map((col, index : number) => {
+        if (!(col.property === '')) {
+          return <div key={index}>
+            <button  onClick={() => propertySelector(index)}> {col.property} </button>
+            </div>
+        }
+      })}
+      {removeFilter && <div>
+        <Button onClick={() => { setRemoveFilter(false); table.filter = null}}
+        text="remove Filter" color="blue"/>
+        <h1> Table Filter: {table.columns[table.filter].label} </h1>
+        </div>
+      }
 
 			{/* delete table */}
 			<Button onClick={() => deleteTable(table.id)} text="Delete table" color="red"/>

--- a/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
@@ -8,14 +8,10 @@ export const TableToolBar = ({
 	addColumnToTable, addRowToTable, deleteTable
 }) => {
 
-  const [showFilter, setShowFilter] = useState(false)
-  const [removeFilter, setRemoveFilter] = useState(!(table.filter === null))
+  
+  
 
-  const propertySelector = (index : number) => {
-    setShowFilter(false)
-    table.filter = index
-    setRemoveFilter(true)
-  }
+  
 
 	return (
 		<>
@@ -67,21 +63,7 @@ export const TableToolBar = ({
           
 				</div>
 			</div>
-      <Button onClick={() => setShowFilter(true)} text="Viewer Filter" color="blue"/>
-      <hr/>
-      {showFilter && table.columns.map((col, index : number) => {
-        if (!(col.property === '')) {
-          return <div key={index}>
-            <button  onClick={() => propertySelector(index)}> {col.property} </button>
-            </div>
-        }
-      })}
-      {removeFilter && <div>
-        <Button onClick={() => { setRemoveFilter(false); table.filter = null}}
-        text="remove Filter" color="blue"/>
-        <h1> Table Filter: {table.columns[table.filter].label} </h1>
-        </div>
-      }
+      
 
 			{/* delete table */}
 			<Button onClick={() => deleteTable(table.id)} text="Delete table" color="red"/>

--- a/meteor-app/imports/ui/Report_View/Report_View.tsx
+++ b/meteor-app/imports/ui/Report_View/Report_View.tsx
@@ -1,13 +1,15 @@
 import { Meteor } from 'meteor/meteor';
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import {useParams} from 'react-router-dom';
 import { Button } from '../components/buttons';
+import { UserContext } from '/imports/api/contexts/userContext';
 import { ReportStructure } from '/imports/api/types/reports';
 
 export const Report_View = () => {
 	const { id } = useParams()
 
-	const [report, setReport] = useState(null)
+  const [report, setReport] = useState(null)
+  const { viewerId } = useContext(UserContext)
 
 	const makeReport = () => {	
 		Meteor.call('Compose_Report', id, (error : Error, result : ReportStructure) => {

--- a/meteor-app/imports/ui/Report_View/Report_View.tsx
+++ b/meteor-app/imports/ui/Report_View/Report_View.tsx
@@ -9,6 +9,7 @@ export const Report_View = () => {
 	const { id } = useParams()
 
   const [report, setReport] = useState(null)
+  const [skipLine, setSkipLine] = useState(null)
   const { viewerId } = useContext(UserContext)
 
 	const makeReport = () => {	
@@ -44,13 +45,18 @@ export const Report_View = () => {
 							
 							{/* rows and cells - if static driven */}
 							{table.rows.map((row) => {
-								return <div key={row.id} className="flex">
-									{row.cells.map((cell) => {
-										return <div key={cell.id} className="flex justify-center items-center h-10 w-40 max-w-sm m-1 border-2 border-indigo-200 rounded-md bg-white" onClick={() => setCellSelected({tableId: table.id, cellId: cell.id})}>
-											<div>{cell.value}</div>
-										</div>
-									})}
-								</div>
+                console.log("value: ", row.cells[0].value)
+                console.log("viewerId: ", viewerId)
+                if (row.cells[0].value == viewerId || viewerId ==  '') {
+                  
+                  return <div key={row.id} className="flex">
+                  {row.cells.map((cell) => {
+                    return <div key={cell.id} className="flex justify-center items-center h-10 w-40 max-w-sm m-1 border-2 border-indigo-200 rounded-md bg-white" onClick={() => setCellSelected({tableId: table.id, cellId: cell.id})}>
+                      <div>{cell.value}</div>
+                    </div>
+                  })}
+                  </div>
+                } 
 							})}
 							
 						</div>

--- a/meteor-app/imports/ui/Report_View/Report_View.tsx
+++ b/meteor-app/imports/ui/Report_View/Report_View.tsx
@@ -47,7 +47,7 @@ export const Report_View = () => {
 							{table.rows.map((row) => {
                 console.log("value: ", row.cells[0].value)
                 console.log("viewerId: ", viewerId)
-                if (row.cells[0].value == viewerId || viewerId ==  '') {
+                if (table.filter === null || row.cells[table.filter].value === viewerId || viewerId ==  '') {
                   
                   return <div key={row.id} className="flex">
                   {row.cells.map((cell) => {

--- a/meteor-app/imports/ui/Report_View/Report_View.tsx
+++ b/meteor-app/imports/ui/Report_View/Report_View.tsx
@@ -45,18 +45,14 @@ export const Report_View = () => {
 							
 							{/* rows and cells - if static driven */}
 							{table.rows.map((row) => {
-                console.log("value: ", row.cells[0].value)
-                console.log("viewerId: ", viewerId)
-                if (table.filter === null || row.cells[table.filter].value === viewerId || viewerId ==  '') {
                   
-                  return <div key={row.id} className="flex">
-                  {row.cells.map((cell) => {
-                    return <div key={cell.id} className="flex justify-center items-center h-10 w-40 max-w-sm m-1 border-2 border-indigo-200 rounded-md bg-white" onClick={() => setCellSelected({tableId: table.id, cellId: cell.id})}>
-                      <div>{cell.value}</div>
-                    </div>
-                  })}
+                return <div key={row.id} className="flex">
+                {row.cells.map((cell) => {
+                  return <div key={cell.id} className="flex justify-center items-center h-10 w-40 max-w-sm m-1 border-2 border-indigo-200 rounded-md bg-white" onClick={() => setCellSelected({tableId: table.id, cellId: cell.id})}>
+                    <div>{cell.value}</div>
                   </div>
-                } 
+                })}
+                </div>
 							})}
 							
 						</div>

--- a/meteor-app/package.json
+++ b/meteor-app/package.json
@@ -9,15 +9,15 @@
     "build:css": "tailwind build styles/global.css -o client/tailwind.css"
   },
   "dependencies": {
-    "@babel/runtime": "^7.11.2",
+    "@babel/runtime": "^7.14.0",
     "bcrypt": "^5.0.1",
     "content-type": "^1.0.4",
     "jsonwebtoken": "^8.5.1",
     "mathjs": "^9.3.2",
     "meteor-node-stubs": "^1.0.1",
     "raw-body": "^2.4.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
     "react-hot-toast": "^1.0.2",
     "react-icons": "^4.2.0",
     "react-router-dom": "^5.2.0",

--- a/meteor-app/server/api/v1/endpoints/viewers/index.ts
+++ b/meteor-app/server/api/v1/endpoints/viewers/index.ts
@@ -45,7 +45,13 @@ WebApp.connectHandlers.use('/v1/viewers/create', async (req, res) => {
 		res.writeHead(400)
 		res.end('invalid Request - Missing "password: string"')
 		return
-	}
+  }
+  
+  if(!json.viewer_id) {
+    res.writeHead(400)
+		res.end('invalid Request - Missing "viewer_id: string"')
+		return
+  }
 
 	if(!json.profile) {
 		res.writeHead(400)

--- a/meteor-app/server/api/v1/seeders/seeder.js
+++ b/meteor-app/server/api/v1/seeders/seeder.js
@@ -3,7 +3,7 @@ import { Meteor } from "meteor/meteor"
 import { Client_Accounts, Report_Data } from "/imports/api/collections"
 
 export const seedUserData = () => {
-	if(Meteor.users.find().count() === 0) {
+	if (Meteor.users.find().count() === 0) {
 
 		const jwt = require('jsonwebtoken')
 
@@ -20,7 +20,7 @@ export const seedUserData = () => {
 
 				const accountId = Client_Accounts.insert(account)
 
-				if(accountId) {
+				if (accountId) {
 					console.log(`Seeder - Account created: ${accountId}`)
 					resolve(accountId)
 				} else {
@@ -38,20 +38,20 @@ export const seedUserData = () => {
 					profile: {
 						first_name: 'Nathan',
 						last_name: 'Jean',
-            accountId: accountId,
-            viewer_id: ''
+						accountId: accountId,
+						viewer_id: ''
 					}
 				})
 
-				if(newUserId) {
+				if (newUserId) {
 					console.log(`Seeder - Editor user created: ${newUserId}`)
 					resolve(newUserId)
 				} else {
 					reject('Failed to create Editor user!!')
 				}
-				
+
 			}).then(userId => {
-				if(userId) {
+				if (userId) {
 					Roles.addUsersToRoles(userId, 'Editor')
 					return userId
 				}
@@ -66,25 +66,25 @@ export const seedUserData = () => {
 				const newUserId = Accounts.createUser({
 					username: 'CraigGeers',
 					email: 'craig@c2s.com',
-          password: 'password',
+					password: 'password',
 					profile: {
 						first_name: 'Craig',
 						last_name: 'Geers',
 						agentId: 'xxxyyyzzz',
-            accountId: accountId,
-            viewer_id: '2',
+						accountId: accountId,
+						viewer_id: '2',
 					}
 				})
 
-				if(newUserId) {
+				if (newUserId) {
 					console.log(`Seeder - View user created: ${newUserId}`)
 					resolve(newUserId)
 				} else {
 					reject('Failed to create Viewer user!!')
 				}
-				
+
 			}).then(userId => {
-				if(userId) {
+				if (userId) {
 					Roles.addUsersToRoles(userId, 'Viewer')
 					return userId
 				}
@@ -98,62 +98,62 @@ export const seedUserData = () => {
 			return new Promise((resolve, reject) => {
 				const newObjectId = Report_Data.insert({
 					accountId: accountId,
-          collectionName: 'Transactions',
-          viewerId: '2',
+					collectionName: 'Transactions',
+					viewer_id: '2',
 					agentId: 'xxxyyyzzz',
 					price: 1500.00
 				})
 
-				if(newObjectId) {
+				if (newObjectId) {
 					console.log(`Seeder - Report Data created: ${newObjectId}`)
 					resolve(newObjectId)
 				} else {
 					reject('Failed to create Viewer user!!')
-        }
+				}
 
-        newObjectId = Report_Data.insert({
+				newObjectId = Report_Data.insert({
 					accountId: accountId,
-          collectionName: 'Transactions',
-          viewerId: '3',
+					collectionName: 'Transactions',
+					viewer_id: '3',
 					agentId: 'xxxyyyzzz',
 					price: 700.00
 				})
 
-				if(newObjectId) {
+				if (newObjectId) {
 					console.log(`Seeder - Report Data created: ${newObjectId}`)
 					resolve(newObjectId)
 				} else {
 					reject('Failed to create Viewer user!!')
-        }
-        
-        const newObjectId2 = Report_Data.insert({
+				}
+
+				const newObjectId2 = Report_Data.insert({
 					accountId: accountId,
-          collectionName: 'Transactions',
-          viewerId: 'xxxyyyzzz',
+					collectionName: 'Transactions',
+					viewer_id: 'xxxyyyzzz',
 					agentId: '2',
 					price: 750.00
 				})
 
-				if(newObjectId2) {
+				if (newObjectId2) {
 					console.log(`Seeder - Report Data created: ${newObjectId2}`)
 					resolve(newObjectId2)
 				} else {
 					reject('Failed to create Viewer user!!')
-        }
+				}
 
-        newObjectId2 = Report_Data.insert({
+				newObjectId2 = Report_Data.insert({
 					accountId: accountId,
 					collectionName: 'Transactions',
 					agentId: '2',
 					price: 1200.00
 				})
 
-				if(newObjectId2) {
+				if (newObjectId2) {
 					console.log(`Seeder - Report Data created: ${newObjectId2}`)
 					resolve(newObjectId2)
 				} else {
 					reject('Failed to create Viewer user!!')
-        }
+				}
 			})
 		}
 

--- a/meteor-app/server/api/v1/seeders/seeder.js
+++ b/meteor-app/server/api/v1/seeders/seeder.js
@@ -98,9 +98,25 @@ export const seedUserData = () => {
 			return new Promise((resolve, reject) => {
 				const newObjectId = Report_Data.insert({
 					accountId: accountId,
-					collectionName: 'Transactions',
+          collectionName: 'Transactions',
+          viewerId: '2',
 					agentId: 'xxxyyyzzz',
-					price: 1000.00
+					price: 1500.00
+				})
+
+				if(newObjectId) {
+					console.log(`Seeder - Report Data created: ${newObjectId}`)
+					resolve(newObjectId)
+				} else {
+					reject('Failed to create Viewer user!!')
+        }
+
+        newObjectId = Report_Data.insert({
+					accountId: accountId,
+          collectionName: 'Transactions',
+          viewerId: '3',
+					agentId: 'xxxyyyzzz',
+					price: 700.00
 				})
 
 				if(newObjectId) {
@@ -110,19 +126,34 @@ export const seedUserData = () => {
 					reject('Failed to create Viewer user!!')
         }
         
-        newObjectId = Report_Data.insert({
+        const newObjectId2 = Report_Data.insert({
+					accountId: accountId,
+          collectionName: 'Transactions',
+          viewerId: 'xxxyyyzzz',
+					agentId: '2',
+					price: 750.00
+				})
+
+				if(newObjectId2) {
+					console.log(`Seeder - Report Data created: ${newObjectId2}`)
+					resolve(newObjectId2)
+				} else {
+					reject('Failed to create Viewer user!!')
+        }
+
+        newObjectId2 = Report_Data.insert({
 					accountId: accountId,
 					collectionName: 'Transactions',
 					agentId: '2',
-					price: 800.00
+					price: 1200.00
 				})
 
-				if(newObjectId) {
-					console.log(`Seeder - Report Data created: ${newObjectId}`)
-					resolve(newObjectId)
+				if(newObjectId2) {
+					console.log(`Seeder - Report Data created: ${newObjectId2}`)
+					resolve(newObjectId2)
 				} else {
 					reject('Failed to create Viewer user!!')
-				}
+        }
 			})
 		}
 

--- a/meteor-app/server/api/v1/seeders/seeder.js
+++ b/meteor-app/server/api/v1/seeders/seeder.js
@@ -38,7 +38,8 @@ export const seedUserData = () => {
 					profile: {
 						first_name: 'Nathan',
 						last_name: 'Jean',
-						accountId: accountId
+            accountId: accountId,
+            viewer_id: ''
 					}
 				})
 
@@ -100,6 +101,20 @@ export const seedUserData = () => {
 					collectionName: 'Transactions',
 					agentId: 'xxxyyyzzz',
 					price: 1000.00
+				})
+
+				if(newObjectId) {
+					console.log(`Seeder - Report Data created: ${newObjectId}`)
+					resolve(newObjectId)
+				} else {
+					reject('Failed to create Viewer user!!')
+        }
+        
+        newObjectId = Report_Data.insert({
+					accountId: accountId,
+					collectionName: 'Transactions',
+					agentId: '2',
+					price: 800.00
 				})
 
 				if(newObjectId) {

--- a/meteor-app/server/api/v1/seeders/seeder.js
+++ b/meteor-app/server/api/v1/seeders/seeder.js
@@ -65,12 +65,13 @@ export const seedUserData = () => {
 				const newUserId = Accounts.createUser({
 					username: 'CraigGeers',
 					email: 'craig@c2s.com',
-					password: 'password',
+          password: 'password',
 					profile: {
 						first_name: 'Craig',
 						last_name: 'Geers',
 						agentId: 'xxxyyyzzz',
-						accountId: accountId,
+            accountId: accountId,
+            viewer_id: '2',
 					}
 				})
 


### PR DESCRIPTION
Added an optional viewerId to collections pushed to be matched to viewer_id

## Description
If the viewerId field is included in the document pushed, then that collection will only be included in the query for the table if that id matches the user's id. There are two ways that the query filter does not go into effect: the user is an editor, in which case they get full access, or the report was made public when made. If the viewerId field is not included in the document, then it is assumed to be public to all. All reports are set to private by default, but I added a button in the report builder to toggle between private and public. 

## Related Monday.com Ticket
- Item #

## Related Issue
- fixes #

## Motivation and Context
This allows reports to customize who can view what

## How Has This Been Tested?
I tested this by creating uploading different data: some with different viewerId's, some without viewerIds. Compose_Report correctly filtered in every test.
<!--- see how your change affects other areas of the code, etc. -->

## Remaining things
-When a new user logs in, their reports don't update automatically, page needs to be refreshed in order for them to show up. Not sure why things aren't updating
- Make the 'Public / Private' status more clear in UI

## Screenshots (if appropriate):
