### PR TITLE
Check security

### DIFF
--- a/meteor-app/.meteor/packages
+++ b/meteor-app/.meteor/packages
@@ -22,3 +22,4 @@ react-meteor-data       # React higher-order component for reactively tracking M
 http
 accounts-password
 alanning:roles
+check

--- a/meteor-app/imports/api/types/accounts.tsx
+++ b/meteor-app/imports/api/types/accounts.tsx
@@ -9,7 +9,6 @@ export interface Viewer {
 	_id: string;
 	username: string;
 	emails: Array<ViewerEmail>;
-	tags: Array<string>;
 	profile: {
 		first_name: string;
 		last_name: string;

--- a/meteor-app/imports/api/types/reports.tsx
+++ b/meteor-app/imports/api/types/reports.tsx
@@ -67,7 +67,7 @@ export interface FormulaQuery {
 export interface ReportData {
 	_id: string | undefined;
 	collection_name: string;
-	viewer_id?: string;
+	viewer_id: string;
 	[key: string]: string | number | Object | null | undefined;
 
 }

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -11,6 +11,7 @@ import { ReportStructure, TableColumn } from '../../api/types/reports'
 import { useParams } from 'react-router-dom';
 import { Report_Structures } from '../../api/collections'
 import { CheckIcon, SelectorIcon } from '@heroicons/react/solid'
+import { verifyReport } from './verifyReport'
 
 
 export const Report_Builder = () => {
@@ -91,7 +92,7 @@ export const Report_Builder = () => {
 	const addColumnToTable = (tableId: string) => {
 		const updatedTables = reportStructure.tables.map(table => {
 			if (table.id === tableId) {
-				table.columns.push({ id: uuidv4(), label: '', property: '', enum: '' })
+				table.columns.push({ id: uuidv4(), label: '', property: '', collection_name: '', enum: '' })
 				table.rows.forEach(row => {
 					row.cells.push({
 						id: uuidv4(),
@@ -272,15 +273,21 @@ export const Report_Builder = () => {
 	}
 
 	const saveReport = () => {
-		Meteor.call('Upsert_Report', reportStructure, (error, result) => {
-			if (error)  {
-				console.log(error)
-				toast.error('Could not save, please complete report')
-			} else if (result) {
-				setReportStructure(result)
-				toast.success('Report Saved!')
-			}
-		})
+		let message = verifyReport(reportStructure)
+		if (message.length == 0) {
+			Meteor.call('Upsert_Report', reportStructure, (error, result) => {
+				if (error)  {
+					console.log(error)
+					toast.error('Could not save')
+				} else if (result) {
+					setReportStructure(result)
+					toast.success('Report Saved!')
+				}
+			})
+		} else {
+			toast.error(message)
+		}
+		
 	}
 
 	const update_tag = (tag) => {

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -273,8 +273,9 @@ export const Report_Builder = () => {
 	}
 
 	const saveReport = () => {
-		let message = verifyReport(reportStructure)
-		if (message.length == 0) {
+		let message = ''
+		message = verifyReport(reportStructure)
+		if (!message) {
 			Meteor.call('Upsert_Report', reportStructure, (error, result) => {
 				if (error)  {
 					console.log(error)

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -139,7 +139,8 @@ export const Report_Builder = () => {
 
 	const addRowToTable = (tableId: string) => {
 		const cells = (tableColumns: Array<TableColumn>) => {
-			return tableColumns.map(() => ({ id: uuidv4() }))
+			// need to at least have value and symbol for cells to render
+			return tableColumns.map((col, i) => ({ id: uuidv4(), value: '', index: i, symbol: '' }))
 		}
 		const updatedTables = reportStructure.tables.map(table => {
 			if (table.id === tableId) {

--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -272,8 +272,10 @@ export const Report_Builder = () => {
 
 	const saveReport = () => {
 		Meteor.call('Upsert_Report', reportStructure, (error, result) => {
-			if (error) console.log(error)
-			if (result) {
+			if (error)  {
+				console.log(error)
+				toast.error('Could not save, please complete report')
+			} else if (result) {
 				setReportStructure(result)
 				toast.success('Report Saved!')
 			}
@@ -426,7 +428,7 @@ export const Report_Builder = () => {
 								{table.columns.map((col, i) => {
 									return <div
 										key={col.id}
-										className={`flex ${selectedColumn?.columnIndex == i? 'bg-blue-100': 'bg-white'} justify-center items-center h-8 w-40 max-w-sm m-1 border-2 border-indigo-200 hover:border-indigo-100 rounded-md text-xs cursor-pointer`}
+										className={`flex ${selectedColumn?.columnIndex == i && selectedColumn?.tableId === table.id?  'bg-blue-100': 'bg-white'} justify-center items-center h-8 w-40 max-w-sm m-1 border-2 border-indigo-200 hover:border-indigo-100 rounded-md text-xs cursor-pointer`}
 										onClick={() => toggleToolBarForColumn(table.id, col, i)}>
 										<span>{col.label}</span>
 									</div>

--- a/meteor-app/imports/ui/Report_Builder/columnToolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/columnToolBar.tsx
@@ -57,6 +57,9 @@ export const ColumnToolBar = ({
 			setSymbolState(column.symbol)
 		}
 	}, [column.symbol])
+	useEffect(() => {
+		setColProperty(column.property)
+	}, [column.property])
 
 	// if the formula string, or formula values change
 	useEffect(() => {

--- a/meteor-app/imports/ui/Report_Builder/columnToolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/columnToolBar.tsx
@@ -53,13 +53,9 @@ export const ColumnToolBar = ({
 		}
 	}, [columnFormula])
 	useEffect(() => {
-		if (column.symbol) {
-			setSymbolState(column.symbol)
-		}
-	}, [column.symbol])
-	useEffect(() => {
+		setSymbolState(column.symbol)
 		setColProperty(column.property)
-	}, [column.property])
+	}, [column])
 
 	// if the formula string, or formula values change
 	useEffect(() => {

--- a/meteor-app/imports/ui/Report_Builder/verifyReport.ts
+++ b/meteor-app/imports/ui/Report_Builder/verifyReport.ts
@@ -14,25 +14,25 @@ import { ReportStructure } from '../../api/types/reports'
 
 export const verifyReport = (report : ReportStructure) => {
 	
-	if (!report) return 'no report found'
+	if (!report) return 'No report found'
 	
-	if (!report.name) return 'please name report'
+	if (!report.name) return 'Please name report'
 
 	if (report.tables.length > 0) {
 		
 		for (const table of report.tables) {
 			
-			if (!table.title) return 'please name table'
+			if (!table.title) return 'Please name table'
 			
-			if (table.type === 'collection' && !table.collection) return 'please select collection for ' + table.title + ' table'
+			if (table.type === 'collection' && !table.collection) return 'Please select collection for ' + table.title + ' table'
 			
 			if (table.columns.length > 0) {
 
 				for (const col of table.columns) {
 
-					if (!col.label) return 'please label columns'
+					if (!col.label) return 'Please label columns'
 
-					if (!col.collection_name) return 'please add property or formula to ' + col.label + ' column in ' + table.title
+					if (!col.collection_name) return 'Please add property or formula to ' + col.label + ' column in ' + table.title
 
 				}
 			}

--- a/meteor-app/imports/ui/Report_Builder/verifyReport.ts
+++ b/meteor-app/imports/ui/Report_Builder/verifyReport.ts
@@ -1,17 +1,5 @@
 import { ReportStructure } from '../../api/types/reports'
 
-
-// {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
-// 	tables : [{id : String, title : String, type : String, 
-// 		columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
-// 		rows : [{id : String, 
-// 			cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
-// 		collection : String, sort_by : String}], 
-// 	formulas : [{id : String, tableId : String, columnId : String, columnIndex : Number, expression : String, 
-// 		// some of the formula types were decided by looking at how they are created in the columnToolBar
-// 		values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
-// 	public : Boolean, tags : [String] }
-
 export const verifyReport = (report : ReportStructure) => {
 	
 	if (!report) return 'No report found'
@@ -23,6 +11,8 @@ export const verifyReport = (report : ReportStructure) => {
 		for (const table of report.tables) {
 			
 			if (!table.title) return 'Please name table'
+
+			if (table.columns.length == 0) return table.title + ' table must have at least one column'
 			
 			if (table.type === 'collection' && !table.collection) return 'Please select collection for ' + table.title + ' table'
 			

--- a/meteor-app/imports/ui/Report_Builder/verifyReport.ts
+++ b/meteor-app/imports/ui/Report_Builder/verifyReport.ts
@@ -1,0 +1,38 @@
+import { ReportStructure } from '../../api/types/reports'
+import { check, Match } from 'meteor/check'
+
+
+// {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
+// 	tables : [{id : String, title : String, type : String, 
+// 		columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
+// 		rows : [{id : String, 
+// 			cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
+// 		collection : String, sort_by : String}], 
+// 	formulas : [{id : String, tableId : String, columnId : String, columnIndex : Number, expression : String, 
+// 		// some of the formula types were decided by looking at how they are created in the columnToolBar
+// 		values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
+// 	public : Boolean, tags : [String] }
+
+export const verify_report = (report : ReportStructure) => {
+	if (!report) return 'no report found'
+	if (!report['name']) return 'please name report'
+	if (report.tables) {
+		report.tables.forEach((table) => {
+			if (!table.title) return 'please name table'
+			if (table.type === 'collection' && !table.collection) return 'please select collection for ' + table.title + ' table'
+			if (table.columns.length > 0) {
+				table.columns.forEach((col) => {
+					
+				})
+			}
+			if (table.rows.length > 0) {
+				table.rows.forEach((row) => {
+					
+				})
+			}
+		})
+		
+	}
+
+	return ''
+}

--- a/meteor-app/imports/ui/Report_Builder/verifyReport.ts
+++ b/meteor-app/imports/ui/Report_Builder/verifyReport.ts
@@ -1,5 +1,4 @@
 import { ReportStructure } from '../../api/types/reports'
-import { check, Match } from 'meteor/check'
 
 
 // {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
@@ -13,25 +12,47 @@ import { check, Match } from 'meteor/check'
 // 		values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
 // 	public : Boolean, tags : [String] }
 
-export const verify_report = (report : ReportStructure) => {
+export const verifyReport = (report : ReportStructure) => {
+	
 	if (!report) return 'no report found'
-	if (!report['name']) return 'please name report'
-	if (report.tables) {
-		report.tables.forEach((table) => {
-			if (!table.title) return 'please name table'
-			if (table.type === 'collection' && !table.collection) return 'please select collection for ' + table.title + ' table'
-			if (table.columns.length > 0) {
-				table.columns.forEach((col) => {
-					
-				})
-			}
-			if (table.rows.length > 0) {
-				table.rows.forEach((row) => {
-					
-				})
-			}
-		})
+	
+	if (!report.name) return 'please name report'
+
+	if (report.tables.length > 0) {
 		
+		for (const table of report.tables) {
+			
+			if (!table.title) return 'please name table'
+			
+			if (table.type === 'collection' && !table.collection) return 'please select collection for ' + table.title + ' table'
+			
+			if (table.columns.length > 0) {
+
+				for (const col of table.columns) {
+
+					if (!col.label) return 'please label columns'
+
+					if (!col.collection_name) return 'please add property or formula to ' + col.label + ' column in ' + table.title
+
+				}
+			}
+		}
+	}
+	
+	if (report.formulas.length > 0) {
+
+		for (const formula of report.formulas) {
+
+			for (const value of formula.values) {
+
+				if (!value.collection_name) return 'Please select collection for ' + value.key
+
+				if (!value.property) return 'Please select property for ' + value.key
+
+				if (!value.queryModifier) return 'Please select filter for ' + value.key
+
+			}
+		}
 	}
 
 	return ''

--- a/meteor-app/server/api/v1/accounts/methods.ts
+++ b/meteor-app/server/api/v1/accounts/methods.ts
@@ -53,16 +53,6 @@ Meteor.methods({
 
 	},
 
-	// username: string;
-	// emails: Array<ViewerEmail>;
-	// profile: {
-	// 	first_name: string;
-	// 	last_name: string;
-	// 	viewer_id: string;
-	// 	tags: Array<string>;
-	// 	[key: string]: string | number | Object | null | undefined;
-	// }
-
 	// used in api, creates a viewer user under an account
 	Create_Viewer_User: function (jwt, json) {
 		check(jwt, String)

--- a/meteor-app/server/api/v1/accounts/methods.ts
+++ b/meteor-app/server/api/v1/accounts/methods.ts
@@ -5,6 +5,7 @@ import { Client_Accounts } from "/imports/api/collections"
 import { getUserDetails } from "../reports/functions";
 import { getAccount } from "./functions";
 import { check } from 'meteor/check'
+import { enforceRole } from '../roles/enforceRoles'
 
 Meteor.methods({
 
@@ -108,10 +109,10 @@ Meteor.methods({
 	},
 
 	Fetch_Viewers_For_Account: function () {
-		if (this.userId && Roles.userIsInRole(this.userId, ['Editor'])) {
-			let accountId = Meteor.users.findOne({ _id: this.userId })?.profile.accountId
-			return Meteor.users.find({ 'profile.accountId': accountId }).fetch()
-		}
+		enforceRole(this.userId, 'Editor')
+		let accountId = Meteor.users.findOne({ _id: this.userId })?.profile.accountId
+		return Meteor.users.find({ 'profile.accountId': accountId }).fetch()
+		
 	},
 
 	Modify_Viewer_User_Profile: function () {

--- a/meteor-app/server/api/v1/accounts/methods.ts
+++ b/meteor-app/server/api/v1/accounts/methods.ts
@@ -2,7 +2,6 @@ import { Meteor } from "meteor/meteor";
 import { Accounts } from 'meteor/accounts-base';
 import { Roles } from 'meteor/alanning:roles'
 import { Client_Accounts } from "/imports/api/collections"
-import { getUserDetails } from "../reports/functions";
 import { getAccount } from "./functions";
 import { check } from 'meteor/check'
 import { enforceRole } from '../roles/enforceRoles'
@@ -56,7 +55,7 @@ Meteor.methods({
 	// used in api, creates a viewer user under an account
 	Create_Viewer_User: function (jwt, json) {
 		check(jwt, String)
-		check(json, {username : String, emails : [String], 
+		check(json, {username : String, emails : String, 
 			profile : {first_name : String, last_name : String, viewer_id : String, tags : [String]}})
 		return new Promise<string>((resolve, reject) => {
 
@@ -101,7 +100,13 @@ Meteor.methods({
 	Fetch_Viewers_For_Account: function () {
 		enforceRole(this.userId, 'Editor')
 		let accountId = Meteor.users.findOne({ _id: this.userId })?.profile.accountId
-		return Meteor.users.find({ 'profile.accountId': accountId }).fetch()
+		if (accountId) {
+			let viewers = Meteor.users.find({ 'profile.accountId': accountId }).fetch()
+			if (viewers) {
+				return viewers
+			}
+		} 
+		return []
 		
 	},
 

--- a/meteor-app/server/api/v1/accounts/methods.ts
+++ b/meteor-app/server/api/v1/accounts/methods.ts
@@ -4,6 +4,7 @@ import { Roles } from 'meteor/alanning:roles'
 import { Client_Accounts } from "/imports/api/collections"
 import { getUserDetails } from "../reports/functions";
 import { getAccount } from "./functions";
+import { check } from 'meteor/check'
 
 Meteor.methods({
 
@@ -21,6 +22,7 @@ Meteor.methods({
 	// used in api, retrieves the client account
 	Fetch_Account: function (jwt) {
 		if (jwt) {
+			check(jwt, String)
 			return Client_Accounts.findOne({ jwt })
 		}
 	},
@@ -30,7 +32,7 @@ Meteor.methods({
 		return getAccount(this.userId)
 	},
 
-	// this might not be neccessary now that I'm just publishing it directly
+	// used in report builder
 	Get_Tags: function () {
 		let account = getAccount(this.userId)
 		return account?.tags
@@ -39,6 +41,8 @@ Meteor.methods({
 	// used in api, retrieves the client account
 	Update_Account: function (jwt, name) {
 		if (jwt && name) { // Update tags
+			check(jwt, String)
+			check(name, String)
 			const update = Client_Accounts.update({ jwt }, { $set: { name: name, updated_at: new Date() } })
 			if (update) return Client_Accounts.findOne({ jwt })
 		}
@@ -48,8 +52,21 @@ Meteor.methods({
 
 	},
 
+	// username: string;
+	// emails: Array<ViewerEmail>;
+	// profile: {
+	// 	first_name: string;
+	// 	last_name: string;
+	// 	viewer_id: string;
+	// 	tags: Array<string>;
+	// 	[key: string]: string | number | Object | null | undefined;
+	// }
+
 	// used in api, creates a viewer user under an account
 	Create_Viewer_User: function (jwt, json) {
+		check(jwt, String)
+		check(json, {username : String, emails : [String], 
+			profile : {first_name : String, last_name : String, viewer_id : String, tags : [String]}})
 		return new Promise<string>((resolve, reject) => {
 
 			const accountId = Client_Accounts.findOne({ jwt })?._id

--- a/meteor-app/server/api/v1/reports/methods.ts
+++ b/meteor-app/server/api/v1/reports/methods.ts
@@ -1,10 +1,11 @@
 import { Meteor } from "meteor/meteor";
 import { _ } from "meteor/underscore";
 import { v4 as uuidv4 } from 'uuid';
-import math from 'mathjs'
+import math, { string } from 'mathjs'
 import { Report_Data, Report_Structures } from '../../../../imports/api/collections';
 import { ReportStructure, ReportData, Table, TableRow, TableColumn, FormulaValue } from '../../../../imports/api/types/reports'
 import { getUserDetails } from "./functions";
+import { check, Match } from 'meteor/check'
 
 Meteor.methods({
 
@@ -13,6 +14,7 @@ Meteor.methods({
 		TODO: restrict to account and user roles
 	*/
 	Insert_Report_Data: function(json) {
+		check(json, Match.ObjectIncluding({collection_name : String}))
 		Report_Data.insert({accountId: 'fyS84mmYeNLqDuaSS', ...json})
 	},
 
@@ -68,6 +70,7 @@ Meteor.methods({
 	TODO: restrict to account and user roles
 */
 	Fetch_Single_Collection_Keys: function (collection_name) {
+		check(collection_name, String)
 
 		const user = getUserDetails(Meteor.user())
 
@@ -91,7 +94,91 @@ Meteor.methods({
 	/*
 		Used to create a new report, or to update one
 	*/
+	// export interface ReportStructure {
+	// 	_id: string | null | undefined; // the mongoId of the report object
+
+	// 	name: string;
+	// 	tables: Array<Table>; // all the tables within a report
+	// 	formulas: Array<Formula>; // the formulas to process when viewing a report
+	// 	public: boolean;	// makes all tables in report public
+	// 	tags: Array<string>; // These are the permissable tags for viewers
+	// }
+	// export interface Table {
+	// 	id: string; // unique id of the table within a report
+	// 	title: string; // title that is used for display
+	// 	type: string; // collection - a table that uses a collection for generating rows. static - user defined dimensions, non looping
+	// 	columns: Array<TableColumn>; // the columns within a table
+	// 	rows: Array<TableRow>; // the rows within a table, if type: collection, rows are generated, if type:static, rows are pre defined by user
+	// 	collection: string; // the collection used if table is collection driven
+	// 	sort_by: string; // defines how the data should be sorted when viewing a report
+	// }
+	// export interface TableColumn {
+	// 	id: string; // the uuid of the column within a table
+	// 	label: string; // used for display
+	// 	formulaId?: string; // if the column has a formula applied to it
+	// 	property: string; // the property of a mongo object, from collection driven tables
+	// 	collection_name: string; // the collection the property belongs to
+	// 	relation_key?: string; // a key name that outlines a relationship to other collection objects
+	// 	enum: string; // defines the intended enumeration for the cell under a column
+	// 	symbol?: string;
+	// }
+	// export interface TableRow {
+	// 	id: string; // the uuid of the row
+	// 	cells: Array<TableCell>; // there should be a cell for each column
+	// }
+	// export interface TableCell {
+	// 	id: string; // a uuid for the cell
+	// 	index: number; // the index of a cell within a row
+	// 	type: string; // input - whatever the user typed, formula - a user crafted formula, property - a property from a document within a collection
+	// 	property: string; // if type is "property", we store the designated property name here
+	// 	propertyValue: string | number | null; // we store values of properties here, which are used with query modifiers
+	// 	value: string; // either what the user typed, or the output of a a formula
+	// 	expression?: string; // the mathmatical expression that was calculated with math.evaluate()
+	// }
+	// export interface Formula {
+	// 	id: string; // the uuid of the formula in a given report
+	// 	tableId: string; // the id of the table, the formula belongs to
+	// 	columnId: string; // the column the formula should be applied to
+	// 	columnIndex: number; // the index of the column, the formula runs for. Used for applying results to row cells
+	// 	expression: string; // the mathmatical expression to be calculated with math.evaluate()
+	// 	values: Array<FormulaValue>; // an array of values, that need to be calculated
+	// }
+	// export interface FormulaValue {
+	// 	key: string; // points to a position in the formula, id like string xxxxxxxxxxxxxxxxxx
+	// 	type: string; // query - "a mongo query", query_count - "a number of objects from a query", pointer - 'grabs the value of another cell or field in the table'
+	// 	operation: string; // sum, min, max, mean - "math.sum, math.min, ..."
+	// 	collection_name: string; // user defined collection, used for display purposes
+	// 	queryModifier?: string; // a modifier for a query, selected from the collection that drives the table
+	// 	query: FormulaQuery; // a json formatted query object for slamming into mongo.find().fetch()
+	// 	property: string; // the property we want to use, when fetching objects in a collection
+	// 	path?: string; // the path traversal for a document fetched by a mongo query
+	// 	columnId?: string; // the column targeted, if type is "pointer"
+	// 	cellIndex?: number; // used to fetch a value from a cell that has already been calculated
+	// }
+	
+	// export interface FormulaQuery {
+	// 	[key: string]: string | number | null;
+	// }
+	
+	// export interface ReportData {
+	// 	_id: string | undefined;
+	// 	collection_name: string;
+	// 	viewer_id?: string;
+	// 	[key: string]: string | number | Object | null | undefined;
+	
+	// }
 	Upsert_Report: function(report: ReportStructure) {
+		console.log('report: ', report)
+		check(report, {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
+			tables : [{id : String, title : String, type : String, 
+				columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
+				rows : [{id : String, 
+					cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
+				collection : String, sort_by : String}], 
+			formulas : [{id : String, tableId : String, columnId : String, columnIndex : Number, expression : String, 
+				// some of the formula types were decided by looking at how they are created in the columnToolBar
+				values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
+			public : Boolean, tags : [String] })
 		const user = getUserDetails(Meteor.user())
 		let action = null;
 		if(!report._id) {

--- a/meteor-app/server/api/v1/reports/methods.ts
+++ b/meteor-app/server/api/v1/reports/methods.ts
@@ -6,6 +6,7 @@ import { Report_Data, Report_Structures } from '../../../../imports/api/collecti
 import { ReportStructure, ReportData, Table, TableRow, TableColumn, FormulaValue } from '../../../../imports/api/types/reports'
 import { getUserDetails } from "./functions";
 import { check, Match } from 'meteor/check'
+import { enforceRole } from '../roles/enforceRoles'
 
 Meteor.methods({
 
@@ -14,6 +15,7 @@ Meteor.methods({
 		TODO: restrict to account and user roles
 	*/
 	Insert_Report_Data: function(json) {
+		enforceRole(this.userId, 'Editor')
 		check(json, Match.ObjectIncluding({collection_name : String}))
 		Report_Data.insert({accountId: 'fyS84mmYeNLqDuaSS', ...json})
 	},
@@ -23,6 +25,7 @@ Meteor.methods({
 		TODO: restrict to user roles
 	*/
 	Fetch_Collection_Names: function() {
+		enforceRole(this.userId, 'Editor')
 		const user = getUserDetails(Meteor.user())
 		let distinct = _.uniq(Report_Data.find({ account_id: user.account_id }, {
 			sort: { collection_name: 1 }, fields: { collection_name: 1 }
@@ -37,6 +40,7 @@ Meteor.methods({
 		TODO: restrict to account and user roles
 	*/
 	Fetch_All_Collection_Keys: function () {
+		enforceRole(this.userId, 'Editor')
 
 		const user = getUserDetails(Meteor.user())
 
@@ -70,6 +74,7 @@ Meteor.methods({
 	TODO: restrict to account and user roles
 */
 	Fetch_Single_Collection_Keys: function (collection_name) {
+		enforceRole(this.userId, 'Editor')
 		check(collection_name, String)
 
 		const user = getUserDetails(Meteor.user())
@@ -91,94 +96,20 @@ Meteor.methods({
 
 	},
 
-	/*
-		Used to create a new report, or to update one
-	*/
-	// export interface ReportStructure {
-	// 	_id: string | null | undefined; // the mongoId of the report object
 
-	// 	name: string;
-	// 	tables: Array<Table>; // all the tables within a report
-	// 	formulas: Array<Formula>; // the formulas to process when viewing a report
-	// 	public: boolean;	// makes all tables in report public
-	// 	tags: Array<string>; // These are the permissable tags for viewers
-	// }
-	// export interface Table {
-	// 	id: string; // unique id of the table within a report
-	// 	title: string; // title that is used for display
-	// 	type: string; // collection - a table that uses a collection for generating rows. static - user defined dimensions, non looping
-	// 	columns: Array<TableColumn>; // the columns within a table
-	// 	rows: Array<TableRow>; // the rows within a table, if type: collection, rows are generated, if type:static, rows are pre defined by user
-	// 	collection: string; // the collection used if table is collection driven
-	// 	sort_by: string; // defines how the data should be sorted when viewing a report
-	// }
-	// export interface TableColumn {
-	// 	id: string; // the uuid of the column within a table
-	// 	label: string; // used for display
-	// 	formulaId?: string; // if the column has a formula applied to it
-	// 	property: string; // the property of a mongo object, from collection driven tables
-	// 	collection_name: string; // the collection the property belongs to
-	// 	relation_key?: string; // a key name that outlines a relationship to other collection objects
-	// 	enum: string; // defines the intended enumeration for the cell under a column
-	// 	symbol?: string;
-	// }
-	// export interface TableRow {
-	// 	id: string; // the uuid of the row
-	// 	cells: Array<TableCell>; // there should be a cell for each column
-	// }
-	// export interface TableCell {
-	// 	id: string; // a uuid for the cell
-	// 	index: number; // the index of a cell within a row
-	// 	type: string; // input - whatever the user typed, formula - a user crafted formula, property - a property from a document within a collection
-	// 	property: string; // if type is "property", we store the designated property name here
-	// 	propertyValue: string | number | null; // we store values of properties here, which are used with query modifiers
-	// 	value: string; // either what the user typed, or the output of a a formula
-	// 	expression?: string; // the mathmatical expression that was calculated with math.evaluate()
-	// }
-	// export interface Formula {
-	// 	id: string; // the uuid of the formula in a given report
-	// 	tableId: string; // the id of the table, the formula belongs to
-	// 	columnId: string; // the column the formula should be applied to
-	// 	columnIndex: number; // the index of the column, the formula runs for. Used for applying results to row cells
-	// 	expression: string; // the mathmatical expression to be calculated with math.evaluate()
-	// 	values: Array<FormulaValue>; // an array of values, that need to be calculated
-	// }
-	// export interface FormulaValue {
-	// 	key: string; // points to a position in the formula, id like string xxxxxxxxxxxxxxxxxx
-	// 	type: string; // query - "a mongo query", query_count - "a number of objects from a query", pointer - 'grabs the value of another cell or field in the table'
-	// 	operation: string; // sum, min, max, mean - "math.sum, math.min, ..."
-	// 	collection_name: string; // user defined collection, used for display purposes
-	// 	queryModifier?: string; // a modifier for a query, selected from the collection that drives the table
-	// 	query: FormulaQuery; // a json formatted query object for slamming into mongo.find().fetch()
-	// 	property: string; // the property we want to use, when fetching objects in a collection
-	// 	path?: string; // the path traversal for a document fetched by a mongo query
-	// 	columnId?: string; // the column targeted, if type is "pointer"
-	// 	cellIndex?: number; // used to fetch a value from a cell that has already been calculated
-	// }
-	
-	// export interface FormulaQuery {
-	// 	[key: string]: string | number | null;
-	// }
-	
-	// export interface ReportData {
-	// 	_id: string | undefined;
-	// 	collection_name: string;
-	// 	viewer_id?: string;
-	// 	[key: string]: string | number | Object | null | undefined;
-	
-	// }
+
 	Upsert_Report: function(report: ReportStructure) {
-		console.log('report: ', report)
-		// check(report, {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
-		// 	tables : [{id : String, title : String, type : String, 
-		// 		columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
-		// 		rows : [{id : String, 
-		// 			cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
-		// 		collection : String, sort_by : String}], 
-		// 	formulas : [{id : String, tableId : String, columnId : String, columnIndex : Number, expression : String, 
-		// 		// some of the formula types were decided by looking at how they are created in the columnToolBar
-		// 		values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
-		// 	public : Boolean, tags : [String] })
+		enforceRole(this.userId, 'Editor')
+		check(report, {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
+			tables : [{id : String, title : String, type : String, 
+				columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
+				rows : [{id : String, 
+					cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
+				collection : String, sort_by : String}], 
+			formulas : [{id : String, tableId : String, columnId : String, columnIndex : Number, expression : String, 
+				// some of the formula types were decided by looking at how they are created in the columnToolBar
+				values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
+			public : Boolean, tags : [String] })
 		const user = getUserDetails(Meteor.user())
 		let action = null;
 		if(!report._id) {
@@ -207,6 +138,10 @@ Meteor.methods({
 	*/
 
 	Compose_Report: function(reportId: string) {
+		if (!this.userId) {
+			throw new Meteor.Error('No Permission', 'user is not logged in')
+		}
+		check(reportId, String)
 
 		let user = getUserDetails(Meteor.user())
 
@@ -218,6 +153,7 @@ Meteor.methods({
 
 		// used to generate rows, if table is collection driven
 		const performQuery = (collection: string) => {
+			check(collection, String)
 			if (report.public || user.role === 'Editor') {
         return Report_Data.find({
 					account_id: user.account_id,
@@ -232,9 +168,18 @@ Meteor.methods({
 			}
 		}
 
+		// export interface ReportData {
+		// 	_id: string | undefined;
+		// 	collection_name: string;
+		// 	viewer_id?: string;
+		// 	[key: string]: string | number | Object | null | undefined;
+		
+		// }
+
 		// generates cells, for a given row, if table is collection driven
 		const generateCells = (columns: Array<TableColumn>, document: ReportData) => {
-
+			check(columns, [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}])
+			check(document, Match.ObjectIncluding({collection_name : String, viewer_id : String}))
 			return columns.map((column, i) => {
 
 				let doc = document
@@ -270,7 +215,13 @@ Meteor.methods({
 
 		// generates rows within a table, if collection driven
 		const generateRows =  (table: Table) => {
+			check(table, {id : String, title : String, type : String, 
+				columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
+				rows : [{id : String, 
+					cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
+				collection : String, sort_by : String})
 			// if type is "static", the rows should already be defined
+			// TODO : allow user to defind rows for static table
 			if(table.type === 'collection') {
 				const collection = performQuery(table.collection)
 

--- a/meteor-app/server/api/v1/reports/methods.ts
+++ b/meteor-app/server/api/v1/reports/methods.ts
@@ -169,16 +169,16 @@ Meteor.methods({
 	// }
 	Upsert_Report: function(report: ReportStructure) {
 		console.log('report: ', report)
-		check(report, {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
-			tables : [{id : String, title : String, type : String, 
-				columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
-				rows : [{id : String, 
-					cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
-				collection : String, sort_by : String}], 
-			formulas : [{id : String, tableId : String, columnId : String, columnIndex : Number, expression : String, 
-				// some of the formula types were decided by looking at how they are created in the columnToolBar
-				values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
-			public : Boolean, tags : [String] })
+		// check(report, {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 
+		// 	tables : [{id : String, title : String, type : String, 
+		// 		columns : [{id : String, label : String, formulaId : Match.Maybe(String), property : Match.Maybe(String), collection_name : String, relation_key : Match.Maybe(String), enum : String, symbol : Match.Maybe(String)}], 
+		// 		rows : [{id : String, 
+		// 			cells : [{id : String, index : Number, type : String, property : String, propertyValue : String, value : String, expression : String}] }], 
+		// 		collection : String, sort_by : String}], 
+		// 	formulas : [{id : String, tableId : String, columnId : String, columnIndex : Number, expression : String, 
+		// 		// some of the formula types were decided by looking at how they are created in the columnToolBar
+		// 		values : [{key : String, type : String, operation : String, collection_name : Match.Maybe(String), queryModifier : String, query : {collection_name : String}, property : Match.Maybe(String), path : Match.Maybe(String), columnId : Match.Maybe(String), cellIndex : Match.Maybe(String)}] }], 
+		// 	public : Boolean, tags : [String] })
 		const user = getUserDetails(Meteor.user())
 		let action = null;
 		if(!report._id) {

--- a/meteor-app/server/api/v1/reports/methods.ts
+++ b/meteor-app/server/api/v1/reports/methods.ts
@@ -1,12 +1,13 @@
 import { Meteor } from "meteor/meteor";
 import { _ } from "meteor/underscore";
 import { v4 as uuidv4 } from 'uuid';
-import math, { string } from 'mathjs'
+import math from 'mathjs'
 import { Report_Data, Report_Structures } from '../../../../imports/api/collections';
 import { ReportStructure, ReportData, Table, TableRow, TableColumn, FormulaValue } from '../../../../imports/api/types/reports'
 import { getUserDetails } from "./functions";
 import { check, Match } from 'meteor/check'
 import { enforceRole } from '../roles/enforceRoles'
+import { getAccount } from "../accounts/functions";
 
 Meteor.methods({
 
@@ -16,8 +17,9 @@ Meteor.methods({
 	*/
 	Insert_Report_Data: function(json) {
 		enforceRole(this.userId, 'Editor')
+		let account = getAccount(this.userId)
 		check(json, Match.ObjectIncluding({collection_name : String}))
-		Report_Data.insert({accountId: 'fyS84mmYeNLqDuaSS', ...json})
+		Report_Data.insert({account_id: account._id, ...json})
 	},
 
 	/*

--- a/meteor-app/server/api/v1/reports/methods.ts
+++ b/meteor-app/server/api/v1/reports/methods.ts
@@ -96,8 +96,9 @@ Meteor.methods({
 
 	},
 
-
-
+	/*
+		Used to create a new report, or to update one
+	*/
 	Upsert_Report: function(report: ReportStructure) {
 		enforceRole(this.userId, 'Editor')
 		check(report, {_id : Match.Maybe(String), account_id : Match.Maybe(String), name : String, 

--- a/meteor-app/server/api/v1/roles/enforceRoles.ts
+++ b/meteor-app/server/api/v1/roles/enforceRoles.ts
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor"
+import { Roles } from 'meteor/alanning:roles'
 /*********************************************************************************
 @description This function will be used primarily to handle error responses from
 asynchronous code execution. To maximize reusability and cover the largest possible
@@ -46,5 +48,6 @@ export const Handle_Error = (reason, message) => {
 }
 export const enforceRole = function(userId, role) {
   if(userId && Roles.userIsInRole(userId, role)) {
-  } else Handle_Error('Auth', 'Not Authorized')
+		return
+  } else throw new Meteor.Error('No Permission', 'user is not in editor role');
 }

--- a/meteor-app/server/api/v1/roles/enforceRoles.ts
+++ b/meteor-app/server/api/v1/roles/enforceRoles.ts
@@ -1,0 +1,50 @@
+/*********************************************************************************
+@description This function will be used primarily to handle error responses from
+asynchronous code execution. To maximize reusability and cover the largest possible
+group of use cases I have created this Error handler with flexibility in mind. The
+handler has three arguments that determine its behavior (two of which are optional)
+@param { String } message A short descriptive String describing the Error in plain
+English
+@param { Object || String || null } error This is an optional parameter which can be
+an Object or a String. Typically it will be an Object passed as the error argument of
+a callback from asynchronous code execution. HIGHLY RECCOMEND INCLUDING THIS WHENEVER
+POSSIBLE
+@param { Object } metaData This is the most beautiful part of this function. Metadata
+is a completely felxible Object that you can fill up with context specific debugging
+information; no limits on the size or depth. This will allow handleError to be adapted
+to any error handling situation
+@return { Error } An Error Object contained a curated String built from the message,
+error param, and metaData
+*********************************************************************************/
+export const handleError = (message, error, metaData = {}) => {
+	let curatedErrorString = `${message}\n\n`
+	// We print the 'error' response from whatever callback or function or Promise. Typically this will be an Object
+	if (error && typeof error === 'string') {
+		// In case a function ever throws a String error we handle it here.
+		curatedErrorString += `Error_String_Passed_To_Handler: ${error}\n\n`
+	} else if (error && typeof error === 'object') {
+		// If it is an Object than we will print the stack and the error Object itself which often have different information
+		if (error instanceof Error) {
+			curatedErrorString += `Stack_For_Error_Passed_To_Handler${error.stack.slice(5)}\n\n`
+		}
+		curatedErrorString += `Error_Object_Passed_To_Handler: ${JSON.stringify(error, undefined, 2)}\n\n`
+	}
+	// Add the logged in userId to metadata every time as this will be needed for most server debugging scenarions; additionally the time and date
+	try {
+		metaData.loggedInUserId = Meteor.userId()
+	} catch (error) {
+		metaData.loggedInUserId = `userId unavailable(possibly the calling code should utilize Meteor.bindEnvironment() to wrap a callback)`
+	}
+	metaData.timeStamp = new Date()
+	// Add the method specific debugging information to the curated Error String that will be printed to the console
+	curatedErrorString += `Metadata: ${JSON.stringify(metaData, undefined, 2)}\n\n`
+	curatedErrorString += `Method_Stack:`
+	return new Error(curatedErrorString)
+}
+export const Handle_Error = (reason, message) => {
+  throw new Meteor.Error(reason, message);
+}
+export const enforceRole = function(userId, role) {
+  if(userId && Roles.userIsInRole(userId, role)) {
+  } else Handle_Error('Auth', 'Not Authorized')
+}


### PR DESCRIPTION
Implemented check package 

## Description
Major Fixes:
- checked arguments for all methods and publications
- created verifyReport function on front end to ensure all fields necessary for viewing are there before method call. If something is missing, a helpful toast.error message is displayed for the user to fix what is missing
- created enforce roles function, and used to check whether user is an editor for all method calls requiring an editor role. If user is not in editor role or is not logged in, throws a Meteor error 'No Permission'
- When a new row is created for a static table, it is made with the fields necessary for viewing, so a static table can be rendered without error. Still has no way to fill in cell values, however.

Minor Fixes:
- tags array removed from outside the profile field in the viewer interface, since it already exists in the profile field
- for selected column UI, only the col index on that specific table is highlighted, instead of all tables

## Related Monday.com Ticket
- Check Package with all Methods and Publications

## Related Issue
- fixes #

## Motivation and Context
This PR improves security in 2 ways: 
1) helps prevent incorrect data being inserted by type checking of arguments passed
2) ensures user is logged in and in editor role in order to do editor things

## How Has This Been Tested?
Reports tested with verifyReport and check package individually:
- No report name, table name, column name
- collection/static table with no property or formula for a column
- collection/static table with property
- collection/static table with formula
- with/without symbols, relation key

To test enforce roles, I accessed the report builder as a viewer and attempted to create reports. I also attempted to call meteor methods directly from the console.

## Screenshots (if appropriate):
