### PR TITLE
report list search

### DIFF
--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -369,7 +369,7 @@ export const Report_Builder = () => {
 	}
 
 	return (
-		<div className='h-screen p-6 bg-gray-100'>
+		<div className='min-h-screen h-full w-full p-6 bg-gray-100'>
 
 			{/* ToolBar */}
 			{showToolBar &&

--- a/meteor-app/imports/ui/Report_List/Report_List.tsx
+++ b/meteor-app/imports/ui/Report_List/Report_List.tsx
@@ -6,6 +6,7 @@ import { Button } from '../components/buttons'
 import { Report_Structures } from '../../api/collections'
 import { UserContext } from '../../api/contexts/userContext';
 import { Redirect } from 'react-router-dom';
+import  SearchBar from '../components/searchbar'
 
 const usePage = () => useTracker(() => {
 	// The publication must also be secure
@@ -24,11 +25,32 @@ export const Report_List = () => {
 		return <Redirect to='/login' />
 	}
 	
+	
 	const { isLoading, reports } = usePage()
+	const [query, setQuery] = useState('')
+	const [reportsShown, setReportsShown] = useState(reports)
+	let reportsShownRegex = new RegExp(query, "i")
+
+	useEffect(() => {
+		filterReports()
+	}, [query])
+
+	useEffect(() => {
+		setReportsShown(reports)
+	}, [reports])
+
+	const filterReports = () => {
+		if(query.length > 0) {
+			let newResults = reports.filter(report => reportsShownRegex.test(report.name))
+			setReportsShown(newResults)
+		} else if (query.length === 0) {
+			setReportsShown(reports)
+		}
+	}
 
   return (
-    <div className='h-screen w-screen p-6 bg-gray-100'>
-			
+    <div className='min-h-screen h-full w-full p-6 bg-gray-100'>
+			<SearchBar query={query} setQuery={setQuery} />
 			<div className="flex justify-between">
 				<p className="text-xl font-semibold tracking-wide">Your Reports:</p>
 				{role === "Editor" && <Link to='/report-builder' className="mr-4">
@@ -36,7 +58,7 @@ export const Report_List = () => {
 				</Link>}
 			</div>
 
-			{!isLoading && reports.map((report, id) => {
+			{!isLoading && reportsShown.map((report, id) => {
 				let hasTag = false
 				tags.forEach((tag) => {
 					if (report.tags.includes(tag)) hasTag = true

--- a/meteor-app/imports/ui/Viewers_List/Viewers_List.tsx
+++ b/meteor-app/imports/ui/Viewers_List/Viewers_List.tsx
@@ -48,7 +48,7 @@ export const Viewers_List = () => {
 	}
 
 	return (
-		<div className='h-screen w-screen p-6 bg-gray-100'>
+		<div className='min-h-screen h-full w-full p-6 bg-gray-100'>
 			<SearchBar query={query} setQuery={setQuery} />
 			<h1 className="text-xl font-semibold tracking-wide my-4">Viewers:</h1>
 			<div className="">


### PR DESCRIPTION
Report list search and filter

## Description
Main Change:
I added the same search feature that is present in the viewers list to the report list. Styles are consistent. Searching is only allowed on report name

Minor Fix: For all 3 main pages, I changed the style of the gray background to be minimum height of screen, but with height as full, this is just so the background will continue when the screen is scrolled.

## Related Monday.com Ticket
- Add Search and Filter to Report list view

## Related Issue
- fixes #

## Motivation and Context
Allows users to find reports easier

## How Has This Been Tested?
- I created a bunch of dummy reports and searched various things
- On Viewers list, report list, and report builder I created enough items on the screen so it would overflow, to make sure the background was persisting with the scroll

## Screenshots (if appropriate):
