### PR TITLE
Data-Overview 

### DIFF
--- a/meteor-app/imports/api/router/router.tsx
+++ b/meteor-app/imports/api/router/router.tsx
@@ -8,6 +8,7 @@ import { Report_View } from '../../ui/Report_View/Report_View';
 import { Report_Builder } from '../../ui/Report_Builder/Report_Builder';
 import { Report_List } from '../../ui/Report_List/Report_List'
 import { Viewers_List } from '../../ui/Viewers_List/Viewers_List'
+import { Data_Overview } from '../../ui/Data_Overview/Data_Overview'
 import { Not_Found } from '../../ui/404_Page/notFound'
 
 export const Main_Router = () => {
@@ -24,6 +25,7 @@ export const Main_Router = () => {
 						<Route path='/report-list' component={Report_List} />
 						<Route path='/report-view/:id?' component={Report_View} />
 						<Route path='/report-builder/:id?' component={Report_Builder} />
+						<Route path='/report-data-overview' component={Data_Overview} />
 						<Route component={Not_Found}/>
 					</Switch>
 				</Router>

--- a/meteor-app/imports/ui/Data_Overview/Data_Overview.tsx
+++ b/meteor-app/imports/ui/Data_Overview/Data_Overview.tsx
@@ -1,0 +1,34 @@
+import { Meteor } from 'meteor/meteor';
+import React, { useState, useEffect, useContext } from 'react'
+import { UserContext } from '/imports/api/contexts/userContext';
+
+export const Data_Overview = () => {
+	const [data, setData] = useState({})
+
+	useEffect(() => {
+		Meteor.call('Fetch_Data', (error : Error, result : ReportStructure) => {
+			if(error) console.log(error)
+			if (result) {
+				console.log(result)
+				setData(result)
+			}
+		})
+	}, [])
+
+	return (
+		<div className="m-4">
+			<h1 className="text-lg font-semibold tracking-wide"> Data: </h1>
+			{data? Object.keys(data).map((collection, i) => {
+				return <div className="m-4" key={i}>
+					<h1 className="font-normal"> {collection}  -  {data[collection].length} </h1>
+					{Object.keys(data[collection][0]).map((obj_key, j) => {
+						return <div key={j}>
+							<h1 className="font-light mx-4"> {obj_key} </h1>
+						</div>
+					})}
+					<span></span>
+				</div>
+			}): <h1>No data available</h1>}
+		</div>
+	);
+};

--- a/meteor-app/imports/ui/components/nav.tsx
+++ b/meteor-app/imports/ui/components/nav.tsx
@@ -31,6 +31,9 @@ const Navbar = () => {
 						<Link to='/report-builder' className="mr-4">
 							Report Builder
 						</Link>
+						<Link to='/report-data-overview' className="mr-4">
+							Report Data
+						</Link>
 					</>
 					}
 					{/* Viewer & Editor Links */}

--- a/meteor-app/server/api/v1/accounts/methods.ts
+++ b/meteor-app/server/api/v1/accounts/methods.ts
@@ -21,7 +21,7 @@ Meteor.methods({
 
 	// finds all report data and returns and object with keys as the collection names
 	Fetch_Data: function () {
-		// TODO: add enforce roles
+		enforceRole(this.userId, 'Editor')
 		let account_obj = getAccount(this.userId)
 		let account = account_obj._id
 		let data = {}


### PR DESCRIPTION
Added Report Data Overview page

## Description
Report Data Overview page displays collection names, total objects under each collection, and the keys for each collection. The page just displays it in plain text. To get the data to display, I added a 'Fetch_Data' method call to get the keys for each collection and formats them : {collection1_name : [key1, key2, key3], collection2_name : [key1, key2, key3, key4]...}.  

## Related Monday.com Ticket
- Show Report Data Overview

## Related Issue
- fixes #

## Motivation and Context
This allows the user to see what data they have pushed up

## How Has This Been Tested?
Accessing the data overview page shows all the data formatted correctly. To ensure security, I attempted to call Fetch_Data when not logged in as an Editor. 

## Screenshots (if appropriate):
