### PR TITLE
incorrect login 

### DIFF
--- a/meteor-app/imports/ui/Login/login.tsx
+++ b/meteor-app/imports/ui/Login/login.tsx
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { Button } from '../components/buttons'
 import { Redirect } from 'react-router-dom';
 import { UserContext } from '/imports/api/contexts/userContext';
+import toast from 'react-hot-toast';
 
 export const Login = () => {
 
@@ -26,12 +27,20 @@ export const Login = () => {
   }
 
 	const handleSubmit = () => {
-		setUsername('') 
-		setPassword('')
-		Meteor.loginWithPassword(username, password, (error) => {
-			if(error) console.log(error);
-			else history.push('report-list')
-		})
+		
+		if (!username || !password) {
+			toast.error('missing username or password')
+		} else {
+			setUsername('') 
+			setPassword('')
+			Meteor.loginWithPassword(username, password, (error) => {
+				if(error) {
+					toast.error('username or password invalid')
+				} 
+				else history.push('report-list')
+			})
+		}
+		
 	}
     
 

--- a/meteor-app/imports/ui/Login/login.tsx
+++ b/meteor-app/imports/ui/Login/login.tsx
@@ -31,13 +31,15 @@ export const Login = () => {
 		if (!username || !password) {
 			toast.error('missing username or password')
 		} else {
-			setUsername('') 
-			setPassword('')
 			Meteor.loginWithPassword(username, password, (error) => {
 				if(error) {
 					toast.error('username or password invalid')
 				} 
-				else history.push('report-list')
+				else {
+					setUsername('')
+					setPassword('')
+					history.push('report-list')
+				}
 			})
 		}
 		


### PR DESCRIPTION
Gave the user a helpful message when a login fails

## Description
- When meteor throws back an error on login, displays a toast error message: 'incorrect username or password'
- Before server is called for login, checks if username or password is blank, and tells the user with a toast message instead of calling server. This keeps meteor from throwing a 400 match error. In this case, the fields don't clear on submit so that the user can input the other field

## Related Monday.com Ticket
- Handle incorrect auth with login

## Related Issue
- fixes #

## Motivation and Context
The user now will know if the login failed

## How Has This Been Tested?
Tested the 9 possible login options:
- incorrect username and password
- correct username incorrect password
- incorrect username correct password
- correct username correct password
- incorrect username missing password
- correct username missing password
- missing username incorrect password
- missing username correct password
- missing username missing password

## Screenshots (if appropriate):
