### PR TITLE
added remove row button for static tables

### DIFF
--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -209,6 +209,16 @@ export const Report_Builder = () => {
 		}
 	}
 
+	const removeRow = (tableId) => {
+		let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
+		reportStructure.tables[tableIndex].rows.pop()
+		setReportStructure(prevState => {
+			return { ...prevState, tables: reportStructure.tables }
+		});
+		// setShowToolBar(false)
+		// setSelectedTable(null)
+	}
+
 	const handleTableTitleUpdate = (tableId, title) => {
 		let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
 		reportStructure.tables[tableIndex].title = title
@@ -392,6 +402,7 @@ export const Report_Builder = () => {
 					handleFormulaUpdate={handleFormulaUpdate}
 					handleFormulaRemoval={handleFormulaRemoval}
 					handleColumnSymbol={handleColumnSymbol}
+					removeRow={removeRow}
 				/>
 			}
 

--- a/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
@@ -6,7 +6,7 @@ import { Label } from '../components/labels'
 
 export const TableToolBar = ({
 	table, setCollectionForTable, handleTableTitleUpdate,
-	handleTableSort, addColumnToTable, addRowToTable, deleteTable
+	handleTableSort, addColumnToTable, addRowToTable, deleteTable, removeRow
 }) => {
 
 	const [toggleDataPicker, setToggleDataPicker] = useState(false)
@@ -100,6 +100,8 @@ export const TableToolBar = ({
 				</div>
 			</div>
       
+			{/* delete table */}
+			<Button onClick={() => removeRow(table.id)} text="Remove row" color="red"/>
 
 			{/* delete table */}
 			<Button onClick={() => deleteTable(table.id)} text="Delete table" color="red"/>

--- a/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/tableToolBar.tsx
@@ -101,7 +101,9 @@ export const TableToolBar = ({
 			</div>
       
 			{/* delete table */}
-			<Button onClick={() => removeRow(table.id)} text="Remove row" color="red"/>
+			{table.type === 'static' && 
+				<Button onClick={() => removeRow(table.id)} text="Remove row" color="red"/>
+			}
 
 			{/* delete table */}
 			<Button onClick={() => deleteTable(table.id)} text="Delete table" color="red"/>

--- a/meteor-app/imports/ui/Report_Builder/toolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/toolBar.tsx
@@ -9,7 +9,7 @@ export const ToolBar = ({
 	addColumnToTable, deleteColumn, addRowToTable, deleteTable,
 	column, columnFormula, handleColumnLabelChange, handleColumnPropertyChange,
 	handleColumnRelationKeyChange,
-	handleFormulaUpdate, handleFormulaRemoval, handleColumnSymbol
+	handleFormulaUpdate, handleFormulaRemoval, handleColumnSymbol, removeRow
 }) => {
 
   return (
@@ -27,6 +27,7 @@ export const ToolBar = ({
 					addColumnToTable={addColumnToTable}
 					addRowToTable={addRowToTable}
 					deleteTable={deleteTable}
+					removeRow={removeRow}
 				/>
 			}
 


### PR DESCRIPTION
added remove row button for static tables

## Description
Added remove row button to the table tool bar. It only shows up for static tables

## Related Monday.com Ticket
- Add remove row button for static tables

## Related Issue
- fixes #

## Motivation and Context
Very minor change. It bothered me that I could add a bunch of rows but couldn't remove them

## How Has This Been Tested?
Created several static tables with differing amounts of rows and columns, and removed rows. 

## Screenshots (if appropriate):
