### PR TITLE
Meteor.user.deny update

### DIFF
--- a/meteor-app/server/api/v1/accounts/security.ts
+++ b/meteor-app/server/api/v1/accounts/security.ts
@@ -1,0 +1,11 @@
+import { Meteor } from 'meteor/meteor';
+
+
+export const security = () => {
+
+	// Deny all client-side updates to user documents
+	Meteor.users.deny({
+		update() { return true; }
+	});
+
+}

--- a/meteor-app/server/main.ts
+++ b/meteor-app/server/main.ts
@@ -15,11 +15,14 @@ import { configureRoles } from './api/v1/roles/roles'
 
 // seeders
 import { seedUserData } from './api/v1/seeders/seeder'
+import { security } from './api/v1/accounts/security';
 
 Meteor.startup(() => {
 
 	configureRoles()
 
 	seedUserData()
+
+	security()
 	
 });


### PR DESCRIPTION
Deny client-side updates to user

## Description
Added security.ts which contains Meteor.users.deny({ update() {return true} }), then ran the tile on startup

## Related Monday.com Ticket
- Item #

## Related Issue
- fixes #

## Motivation and Context
User.profile is editable on the client-side by default. This would cause issues for us if a user were able to edit their profile directly, so this disables it.

## How Has This Been Tested?
Attempted to directly update user.profile through console as both a logged in user and non-logged in user

## Screenshots (if appropriate):
