### PR TITLE
auto-assign relation key

### DIFF
--- a/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
+++ b/meteor-app/imports/ui/Report_Builder/Report_Builder.tsx
@@ -191,14 +191,6 @@ export const Report_Builder = () => {
 		});
 	}
 
-	const handleColumnRelationKeyChange = (tableId, columnIndex, relation_key) => {
-		let tableIndex = reportStructure.tables.findIndex(table => table.id === tableId)
-		reportStructure.tables[tableIndex].columns[columnIndex].relation_key = relation_key
-		setReportStructure(prevState => {
-			return { ...prevState, tables: reportStructure.tables }
-		});
-	}
-
 	const deleteTable = (tableId) => {
 		let c = confirm("Are you sure you want to delete this table?")
 		if (c) {
@@ -410,7 +402,6 @@ export const Report_Builder = () => {
 					columnFormula={selectedColumnFormula}
 					handleColumnLabelChange={handleColumnLabelChange}
 					handleColumnPropertyChange={handleColumnPropertyChange}
-					handleColumnRelationKeyChange={handleColumnRelationKeyChange}
 					handleFormulaUpdate={handleFormulaUpdate}
 					handleFormulaRemoval={handleFormulaRemoval}
 					handleColumnSymbol={handleColumnSymbol}

--- a/meteor-app/imports/ui/Report_Builder/columnToolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/columnToolBar.tsx
@@ -11,7 +11,6 @@ export const ColumnToolBar = ({
 	reportStructure, column, columnIndex, tableId, 
 	handleColumnLabelChange, handleColumnPropertyChange,
 	handleFormulaUpdate, handleFormulaRemoval, columnFormula,
-	handleColumnRelationKeyChange,
 	deleteColumn, userCollections, handleColumnSymbol
 }) => {
 
@@ -262,19 +261,6 @@ export const ColumnToolBar = ({
 				<div className="flex">
 					<Button onClick={() => saveFormula()} text={'Save Formula'} color="blue"/>
 					<Button onClick={() => removeFormula()} text={'Remove Formula'} color="red"/>
-				</div>
-			}
-
-			{/* Column relation_key - if no formula */}
-			{!formulaString &&
-				<div className="mb-4">
-					<Input 
-						placeholder={'Enter relation key'}
-						label={"Relation key:"} 
-						value={column.relation_key} 
-						onClick={() => handleRelationPicker()}
-						disabled={true}
-						/>
 				</div>
 			}
 			

--- a/meteor-app/imports/ui/Report_Builder/toolBar.tsx
+++ b/meteor-app/imports/ui/Report_Builder/toolBar.tsx
@@ -8,7 +8,6 @@ export const ToolBar = ({
 	userCollections, setCollectionForTable, 
 	addColumnToTable, deleteColumn, addRowToTable, deleteTable,
 	column, columnFormula, handleColumnLabelChange, handleColumnPropertyChange,
-	handleColumnRelationKeyChange,
 	handleFormulaUpdate, handleFormulaRemoval, handleColumnSymbol, removeRow
 }) => {
 
@@ -39,7 +38,6 @@ export const ToolBar = ({
 					tableId={column.tableId}
 					handleColumnLabelChange={handleColumnLabelChange}
 					handleColumnPropertyChange={handleColumnPropertyChange}
-					handleColumnRelationKeyChange={handleColumnRelationKeyChange}
 					deleteColumn={deleteColumn}
 					userCollections={userCollections}
 					handleFormulaUpdate={handleFormulaUpdate}

--- a/meteor-app/imports/ui/Report_Builder/verifyReport.ts
+++ b/meteor-app/imports/ui/Report_Builder/verifyReport.ts
@@ -12,17 +12,19 @@ export const verifyReport = (report : ReportStructure) => {
 			
 			if (!table.title) return 'Please name table'
 
-			if (table.columns.length == 0) return table.title + ' table must have at least one column'
+			if (!table.collection) return 'Please assign collection to \"' + table.title + '\"'
+
+			if (table.columns.length == 0) return '\"' + table.title + '\" table must have at least one column'
 			
-			if (table.type === 'collection' && !table.collection) return 'Please select collection for ' + table.title + ' table'
+			if (table.type === 'collection' && !table.collection) return 'Please select collection for \"' + table.title + '\"'
 			
 			if (table.columns.length > 0) {
 
 				for (const col of table.columns) {
 
-					if (!col.label) return 'Please label columns'
+					if (!col.label) return 'Please label columns in \"' + table.title + '\"'
 
-					if (!col.collection_name) return 'Please add property or formula to ' + col.label + ' column in ' + table.title
+					if (!col.collection_name) return 'Please add property or formula to \"' + col.label + '\" column in \"' + table.title + '\"'
 
 				}
 			}

--- a/meteor-app/server/api/v1/reports/methods.ts
+++ b/meteor-app/server/api/v1/reports/methods.ts
@@ -189,18 +189,33 @@ Meteor.methods({
 
 				let type = '', property = null, propertyValue = null, value: number | Object| string | null | undefined = 0;
 
-				// if there is a relation key, we overide the document from table collection, to the column specific collection
-				if(column.relation_key) {
+				// auto assign relation key for table join
+				if (column.collection_name != doc.collection_name) {
+					// query used as the WHERE for the mongo find
 					let query = {
 						account_id: user.account_id,
 						collection_name: column.collection_name,
 					}
+					// if report is private, add viewer_id to field for another WHERE filter
 					if (!report.public && user.role === 'Viewer') {
 						query['viewer_id'] = user.viewer_id
 					}
-					query[column.relation_key] = doc[column.relation_key]
+					// set relation key to be whatever similar key, most likely viewer_id
+					// assume all docs in collection have same format
+					let column_collection = Report_Data.findOne({
+						account_id: user.account_id,
+						collection_name: column.collection_name
+					})
+					let { _id, collection_name, account_id, ...filtered_column_collection } = column_collection
+					let column_collection_keys = Object.keys(filtered_column_collection)
+					let doc_keys = Object.keys(doc)
+					let shared_key = column_collection_keys.filter(key => doc_keys.includes(key))
+					if (shared_key.length) {
+						query[shared_key[0]] = doc[shared_key[0]]
+					}
 					doc = Report_Data.findOne(query)
 				}
+
 				// a column should only have either a formula, or a property assigned, never both
 				property = column.property
 				propertyValue = doc[property]


### PR DESCRIPTION
- auto assign relation key to join tables
- require collection selection for collection driven tables

## Description
For a collection driven table, if the user wants to display data that is not a part of the collection, instead of having them assign a join key manually, the compose report method will detect the different collection and assign the key based on a shared key. I removed from the UI the ability to select the relation key. 
In order for a collection driven table to have rows, a collection must be specified. I added this check into verifyReports as well.
Minor change: for the verify reports error messages, added quotes around table and column names to make less confusing

## Related Monday.com Ticket
- Identify what is confusing with report builder

## Related Issue
- fixes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- table was made with Agents.last_name and Transactions.price as Agent driven and then Transactions driven
- collection driven table was made without specifying collection

## Screenshots (if appropriate):
